### PR TITLE
Deploy real alfajores relayers

### DIFF
--- a/bin/deploy-via-gcloud.sh
+++ b/bin/deploy-via-gcloud.sh
@@ -15,12 +15,21 @@ deploy_via_gcloud() {
 	fi
 	env=$1
 
-	# Select the correct environment
-	terraform -chdir=infra workspace select "${env}"
-
-	# Load the project variables
+	# Load the current project variables
 	script_dir=$(dirname "$0")
 	source "${script_dir}/get-project-vars.sh"
+
+	# Get the cached & actual Terraform workspace
+	current_workspace=$(terraform -chdir=infra workspace show)
+	cached_workspace=${workspace}
+
+	# Select the desired workspace
+	terraform -chdir=infra workspace select "${env}"
+
+	# Determine if cache should be invalidated to not deploy to the wrong environment
+	if [[ ${current_workspace} != "${cached_workspace}" ]]; then
+		source "${script_dir}/get-project-vars.sh" --invalidate_cache
+	fi
 
 	# Deploy the Google Cloud Function
 	echo "Deploying to Google Cloud Functions..."

--- a/bin/get-function-logs.sh
+++ b/bin/get-function-logs.sh
@@ -14,11 +14,21 @@ get_function_logs() {
 	fi
 	env=$1
 
+	# Get the current Terraform workspace
+	current_workspace=$(terraform -chdir=infra workspace show)
+
+	# Select the desired workspace
 	terraform -chdir=infra workspace select "${env}"
+
+	# Determine if cache should be invalidated
+	invalidate_cache=""
+	if [[ ${current_workspace} != "${env}" ]]; then
+		invalidate_cache="--invalidate-cache"
+	fi
 
 	# Load the project variables
 	script_dir=$(dirname "$0")
-	source "${script_dir}/get-project-vars.sh"
+	source "${script_dir}/get-project-vars.sh" "${invalidate_cache}"
 
 	# Fetch raw logs
 	raw_logs=$(gcloud logging read "resource.labels.function_name=${function_name}" \

--- a/bin/get-project-vars.sh
+++ b/bin/get-project-vars.sh
@@ -167,6 +167,7 @@ main() {
 
 	if [[ ${cache_loaded} -eq 0 ]]; then
 		printf "Using cached values from %s:\n" "${cache_file}"
+		printf " - Environment: \033[1m%s\033[0m\n" "${workspace}"
 		printf " - Project ID: \033[1m%s\033[0m\n" "${project_id}"
 		printf " - Project Name: \033[1m%s\033[0m\n" "${project_name}"
 		printf " - Region: \033[1m%s\033[0m\n" "${region}"

--- a/bin/get-project-vars.sh
+++ b/bin/get-project-vars.sh
@@ -159,7 +159,7 @@ invalidate_cache() {
 main() {
 	if [[ ${1-} == "--invalidate-cache" ]]; then
 		invalidate_cache
-		exit 0
+		return 0
 	fi
 
 	load_cache

--- a/bin/test-deployed-function.sh
+++ b/bin/test-deployed-function.sh
@@ -46,7 +46,7 @@ test_deployed_function() {
 
 	echo "🌀 Emitting a Pubsub event to trigger the function..."
 	printf "\n"
-	gcloud pubsub topics publish "${topic_name}" --message='{"rate_feed_name": "PHP/USD", "relayer_address": "0xF93c6fe760F09f19880f57D643a17A515c11165c"}'
+	gcloud pubsub topics publish "${topic_name}" --message="{\"rate_feed_name\": \"${rate_feed_id}\", \"relayer_address\": \"${address}\"}"
 	printf "\n"
 
 	echo "✅ Pubsub event emitted!"

--- a/bin/test-deployed-function.sh
+++ b/bin/test-deployed-function.sh
@@ -6,24 +6,47 @@ set -u          # Treat unset variables as an error when substituting
 # Manually triggers a deployed Cloud Function by emitting a Pubsub event.
 # Requires an environment arg (e.g., staging, production).
 test_deployed_function() {
-	# Check if environment parameter is provided
-	if [[ $# -ne 1 ]]; then
-		echo "Usage: $0 <env>"
-		echo "Example: $0 staging"
+	# Check if environment and rate feed ID parameters are provided
+	if [[ $# -ne 2 ]]; then
+		echo "Usage: $0 <env> <rate_feed_id>"
+		echo "Example: $0 staging PHP/USD"
 		exit 1
 	fi
 	env=$1
+	rate_feed_id=$2
+
+	# Validate rate feed ID format
+	if ! [[ ${rate_feed_id} =~ ^[A-Z]{3,4}/[A-Z]{3,4}$ ]]; then
+		echo "❌ Error: Invalid rate feed ID format. It should be in the form of 'PHP/USD' (3-4 digits per currency symbol)."
+		exit 1
+	fi
+
+	json_key=$(echo "${rate_feed_id}" | tr '[:upper:]' '[:lower:]' | tr '/' '_')
 
 	terraform -chdir=infra workspace select "${env}"
 
 	# Load the project variables
 	script_dir=$(dirname "$0")
 	source "${script_dir}/get-project-vars.sh"
+	printf "\n"
+
+	# Read the relayer addresses JSON file and extract the address
+	json_file="infra/relayer_addresses.json"
+	if [[ ! -f ${json_file} ]]; then
+		echo "❌ Error: ${json_file} file not found in the script directory."
+		exit 1
+	fi
+
+	address=$(jq -r ".${env}.\"${json_key}\"" "${json_file}")
+
+	if [[ ${address} == "null" ]]; then
+		echo "❌ Error: Address not found for rate feed ID '${rate_feed_id}' in environment '${env}'."
+		exit 1
+	fi
 
 	echo "🌀 Emitting a Pubsub event to trigger the function..."
 	printf "\n"
-	# TODO: Update the relayer address to a real one once we have one deployed in prod
-	gcloud pubsub topics publish "${topic_name}" --message='{"rate_feed_name": "TEST/USD", "relayer_address": "0x13374935239dacdecf7c5ba76d8de40b077b7420"}'
+	gcloud pubsub topics publish "${topic_name}" --message='{"rate_feed_name": "PHP/USD", "relayer_address": "0xF93c6fe760F09f19880f57D643a17A515c11165c"}'
 	printf "\n"
 
 	echo "✅ Pubsub event emitted!"

--- a/infra/cloud_function.tf
+++ b/infra/cloud_function.tf
@@ -28,9 +28,7 @@ resource "google_cloudfunctions2_function" "relay" {
       RELAYER_PK_SECRET_ID = google_secret_manager_secret.relayer_pk.secret_id
       # Logs execution ID for easier debugging => https://cloud.google.com/functions/docs/monitoring/logging#viewing_runtime_logs
       LOG_EXECUTION_ID = "true"
-      # TODO: Remove this before go-live
-      # For testing purposes until we start to deploy on Mainnet
-      NODE_ENV = "development"
+      NODE_ENV         = terraform.workspace == "staging" ? "development" : "production"
     }
   }
 

--- a/infra/relayer_addresses.json
+++ b/infra/relayer_addresses.json
@@ -1,8 +1,7 @@
 {
   "staging": {
-    "php_usd": "0x3005a33a9782f4c1ccfa0ffdb87a034b95b7ad90"
+    "php_usd": "0xF93c6fe760F09f19880f57D643a17A515c11165c",
+    "celo_php": "0xe9c1d593672A28eE3E3817545D7c2b8397b7871E"
   },
-  "prod": {
-    "php_usd": "0x3005a33a9782f4c1ccfa0ffdb87a034b95b7ad90"
-  }
+  "prod": {}
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,14 +2,16 @@ import { JSONSchemaType, envSchema } from "env-schema";
 
 export interface Env {
   GCP_PROJECT_ID: string;
+  NODE_ENV: string;
   RELAYER_PK_SECRET_ID: string;
 }
 
 const schema: JSONSchemaType<Env> = {
   type: "object",
-  required: ["GCP_PROJECT_ID", "RELAYER_PK_SECRET_ID"],
+  required: ["GCP_PROJECT_ID", "NODE_ENV", "RELAYER_PK_SECRET_ID"],
   properties: {
     GCP_PROJECT_ID: { type: "string" },
+    NODE_ENV: { type: "string" },
     RELAYER_PK_SECRET_ID: { type: "string" },
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,21 +2,7 @@ import { cloudEvent, CloudEvent } from "@google-cloud/functions-framework";
 
 import getLogger from "./logger";
 import relay from "./relay";
-
-interface PubsubData {
-  subscription: string;
-  message: {
-    messageId: string;
-    publishTime: string;
-    data: string;
-    attributes?: Record<string, string>;
-  };
-}
-
-interface RelayRequested {
-  rate_feed_name: string;
-  relayer_address: string;
-}
+import type { PubsubData, RelayRequested } from "./types";
 
 cloudEvent("relay", async (event: CloudEvent<PubsubData>) => {
   // For better log readability

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 import { cloudEvent, CloudEvent } from "@google-cloud/functions-framework";
-
+import config from "./config";
 import getLogger from "./logger";
 import relay from "./relay";
 import type { PubsubData, RelayRequested } from "./types";
+
+const isMainnet = config.NODE_ENV !== "development";
+const network = isMainnet ? "Celo" : "Alfajores";
 
 cloudEvent("relay", async (event: CloudEvent<PubsubData>) => {
   // For better log readability
@@ -37,10 +40,10 @@ cloudEvent("relay", async (event: CloudEvent<PubsubData>) => {
     };
   }
 
-  const logger = getLogger(rateFeedName);
+  const logger = getLogger(rateFeedName, network);
   logger.info(`Relay request received for ${relayerAddress}`);
 
-  const ok = await relay(relayerAddress, rateFeedName);
+  const ok = await relay(relayerAddress, rateFeedName, network);
   if (!ok) {
     return { status: "error", message: "Relay failed" };
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,11 +2,17 @@ import { LoggingWinston } from "@google-cloud/logging-winston";
 import type { LogEntry } from "winston";
 import winston, { format } from "winston";
 
-export default function getLogger(rateFeed: string): winston.Logger {
+export default function getLogger(
+  rateFeed: string,
+  network: string,
+): winston.Logger {
   const isCloudFunction = process.env.FUNCTION_TARGET !== undefined;
   const transports: winston.transport[] = [
     // Cloud Logging transport
-    new LoggingWinston({ labels: { rateFeed }, prefix: rateFeed }),
+    new LoggingWinston({
+      labels: { rateFeed, network },
+      prefix: `${rateFeed} ${network}`,
+    }),
     // Console transport only when running locally, to avoid duplicate logs in GCP
     ...(!isCloudFunction
       ? [
@@ -15,7 +21,7 @@ export default function getLogger(rateFeed: string): winston.Logger {
             format: format.combine(
               format.timestamp(),
               format.printf((log: LogEntry) => {
-                return `[${log.level}] ${String(log.timestamp)}: [${rateFeed}] ${log.message}`;
+                return `[${log.level}] ${String(log.timestamp)}: [${rateFeed}] [${network}] ${log.message}`;
               }),
             ),
           }),

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -44,6 +44,18 @@ export default async function relay(
   const publicClient = getPublicClient();
   const wallet = await getWalletClient();
 
+  // Check if the address is a contract
+  const contractCode = await publicClient.getCode({
+    address: relayerAddress as Address,
+  });
+
+  if (!contractCode || contractCode === "0x") {
+    logger.error(
+      `Relay failed. Relayer address ${relayerAddress} is not a contract.`,
+    );
+    return false; // Not a contract
+  }
+
   const contract = getContract({
     address: relayerAddress as Address,
     abi: relayerAbi,

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -1,23 +1,24 @@
 import {
   Address,
   BaseError,
+  ContractFunctionRevertedError,
   createPublicClient,
   createWalletClient,
-  ContractFunctionRevertedError,
   getContract,
   http,
   WalletClient,
 } from "viem";
-import { celo, celoAlfajores } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
+import { celo, celoAlfajores } from "viem/chains";
 
 import config from "./config";
-import getLogger from "./logger";
 import getSecret from "./get-secret";
+import getLogger from "./logger";
 import { relayerAbi } from "./relayer-abi";
 
+const isMainnet = config.NODE_ENV !== "development";
+
 function getPublicClient() {
-  const isMainnet = process.env.NODE_ENV !== "development";
   return createPublicClient({
     chain: isMainnet ? celo : celoAlfajores,
     transport: http(),
@@ -25,7 +26,6 @@ function getPublicClient() {
 }
 
 async function getWalletClient(): Promise<WalletClient> {
-  const isMainnet = process.env.NODE_ENV !== "development";
   const pk = await getSecret(config.RELAYER_PK_SECRET_ID);
 
   return createWalletClient({
@@ -38,8 +38,9 @@ async function getWalletClient(): Promise<WalletClient> {
 export default async function relay(
   relayerAddress: string,
   rateFeedName: string,
+  network: string,
 ): Promise<boolean> {
-  const logger = getLogger(rateFeedName);
+  const logger = getLogger(rateFeedName, network);
   const publicClient = getPublicClient();
   const wallet = await getWalletClient();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+export interface PubsubData {
+  subscription: string;
+  message: {
+    messageId: string;
+    publishTime: string;
+    data: string;
+    attributes?: Record<string, string>;
+  };
+}
+
+export interface RelayRequested {
+  rate_feed_name: string;
+  relayer_address: string;
+}


### PR DESCRIPTION
### Done
- [x] Added real alfajores relayer addresses from https://github.com/mento-protocol/mento-deployment/pull/206
- [x] Added network name to all logs (so it's easier to tell if a relay tx happened on mainnet or alfajores)
- [x] Throw an error if relayer address is an EOA and not a contract address
- [x] Update `npm run test:staging|prod` to accept a rate feed name as param
- [x] **Deployed latest infra to both staging and production** (with no relayer addresses currently live on prod, so there shouldn't be any jobs on prod for now)

### How to test
- Run `npm run logs` and see if the cloud function on staging is regularly called for both PHP/USD and CELO/PHP
- Check that the relay TXs are succeeding
- Run `npm run logs:prod` and see that no relay requests are happening (as no relayers are deployed to mainnet rn)
- Run a function locally via `npm run dev` and test it via `npm test`
- In the 'npm start' task, change `NODE_ENV=development` to `NODE_ENV=production` and restart the local function
- Run `npm test` again and see that the network name prefix in the logs has changed from `alfajores` to `celo`
- Try triggering a staging relayer manually with a valid rate feed via `npm run test:staging PHP/USD`
- Try triggering a staging relayer manually with a non-existing rate feed via `npm run test:staging AAA/USD` (should error)