### PR TITLE
feat: use a different account per rate feed

### DIFF
--- a/.trunk/configs/osv-scanner.toml
+++ b/.trunk/configs/osv-scanner.toml
@@ -1,0 +1,4 @@
+[[IgnoredVulns]]
+id = "GHSA-952p-6rrq-rcjv"
+ignoreUntil = 2024-12-31 # TODO: Reevaluate end of year if there's a fix available then
+reason = "micromatch vulnerability is not fixable atm"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
    billing_account = "<our-billing-account-id>"
 
    # Get it via `gcloud secrets versions access latest --secret relayer-mnemonic-staging`
+   # Note that the mnemonic is the same for both the staging and prod environments.
    # To fetch secrets, you'll need the `Secret Manager Secret Accessor` IAM role assigned to your Google Cloud Account
    relayer_mnemonic      = "<relayer-mnemonic>"
    ```

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@
    # Get it via `gcloud billing accounts list` (pick the GmbH account)
    billing_account = "<our-billing-account-id>"
 
-   # Get it via `gcloud secrets versions access latest --secret relayer-private-key-staging`
+   # Get it via `gcloud secrets versions access latest --secret relayer-mnemonic-staging`
    # To fetch secrets, you'll need the `Secret Manager Secret Accessor` IAM role assigned to your Google Cloud Account
-   relayer_pk      = "<relayer-private-key>"
+   relayer_mnemonic      = "<relayer-mnemonic>"
    ```
 
 ## Debugging Local Problems

--- a/infra/cloud_function.tf
+++ b/infra/cloud_function.tf
@@ -24,8 +24,8 @@ resource "google_cloudfunctions2_function" "relay" {
     timeout_seconds       = 60
 
     environment_variables = {
-      GCP_PROJECT_ID       = module.oracle_relayer.project_id
-      RELAYER_PK_SECRET_ID = google_secret_manager_secret.relayer_pk.secret_id
+      GCP_PROJECT_ID             = module.oracle_relayer.project_id
+      RELAYER_MNEMONIC_SECRET_ID = google_secret_manager_secret.relayer_mnemonic.secret_id
       # Logs execution ID for easier debugging => https://cloud.google.com/functions/docs/monitoring/logging#viewing_runtime_logs
       LOG_EXECUTION_ID = "true"
       NODE_ENV         = terraform.workspace == "staging" ? "development" : "production"

--- a/infra/local-dotenv-file.tf
+++ b/infra/local-dotenv-file.tf
@@ -2,6 +2,6 @@ resource "local_file" "env_file" {
   filename = "${path.module}/../.env"
   content  = <<-EOT
     GCP_PROJECT_ID=${module.oracle_relayer.project_id}
-    RELAYER_PK_SECRET_ID=${var.relayer_pk_secret_id}-${terraform.workspace}
+    RELAYER_MNEMONIC_SECRET_ID=${var.relayer_mnemonic_secret_id}-${terraform.workspace}
   EOT
 }

--- a/infra/secret-manager.tf
+++ b/infra/secret-manager.tf
@@ -1,13 +1,13 @@
-resource "google_secret_manager_secret" "relayer_pk" {
+resource "google_secret_manager_secret" "relayer_mnemonic" {
   project   = module.oracle_relayer.project_id
-  secret_id = "${var.relayer_pk_secret_id}-${terraform.workspace}"
+  secret_id = "${var.relayer_mnemonic_secret_id}-${terraform.workspace}"
 
   replication {
     auto {}
   }
 }
 
-resource "google_secret_manager_secret_version" "relayer_pk" {
-  secret      = google_secret_manager_secret.relayer_pk.id
-  secret_data = var.relayer_pk
+resource "google_secret_manager_secret_version" "relayer_mnemonic" {
+  secret      = google_secret_manager_secret.relayer_mnemonic.id
+  secret_data = var.relayer_mnemonic
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -20,12 +20,12 @@ variable "billing_account" {
   type = string
 }
 
-variable "relayer_pk_secret_id" {
+variable "relayer_mnemonic_secret_id" {
   type    = string
-  default = "relayer-private-key"
+  default = "relayer-mnemonic"
 }
 
-variable "relayer_pk" {
+variable "relayer_mnemonic" {
   type      = string
   sensitive = true
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'npm run build && npm run start'",
     "gcp-build": "npm run build",
     "generate:env": "terraform -chdir=infra apply -target=local_file.env_file",
+    "get:relayer:address": "NODE_ENV=development ts-node ./src/get-relayer-address.ts",
     "logs": "npm run logs:function:staging",
     "logs:function:prod": "./bin/get-function-logs.sh prod",
     "logs:function:staging": "./bin/get-function-logs.sh staging",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'npm run build && npm run start'",
     "gcp-build": "npm run build",
     "generate:env": "terraform -chdir=infra apply -target=local_file.env_file",
-    "get:relayer:address": "NODE_ENV=development npx ts-node ./src/get-relayer-address.ts",
+    "get:relayer:signer": "NODE_ENV=development npx ts-node ./src/get-relayer-signer.ts",
     "logs": "npm run logs:function:staging",
     "logs:function:prod": "./bin/get-function-logs.sh prod",
     "logs:function:staging": "./bin/get-function-logs.sh staging",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'npm run build && npm run start'",
     "gcp-build": "npm run build",
     "generate:env": "terraform -chdir=infra apply -target=local_file.env_file",
-    "get:relayer:address": "NODE_ENV=development ts-node ./src/get-relayer-address.ts",
+    "get:relayer:address": "NODE_ENV=development npx ts-node ./src/get-relayer-address.ts",
     "logs": "npm run logs:function:staging",
     "logs:function:prod": "./bin/get-function-logs.sh prod",
     "logs:function:staging": "./bin/get-function-logs.sh staging",

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,16 +3,16 @@ import { JSONSchemaType, envSchema } from "env-schema";
 export interface Env {
   GCP_PROJECT_ID: string;
   NODE_ENV: string;
-  RELAYER_PK_SECRET_ID: string;
+  RELAYER_MNEMONIC_SECRET_ID: string;
 }
 
 const schema: JSONSchemaType<Env> = {
   type: "object",
-  required: ["GCP_PROJECT_ID", "NODE_ENV", "RELAYER_PK_SECRET_ID"],
+  required: ["GCP_PROJECT_ID", "NODE_ENV", "RELAYER_MNEMONIC_SECRET_ID"],
   properties: {
     GCP_PROJECT_ID: { type: "string" },
     NODE_ENV: { type: "string" },
-    RELAYER_PK_SECRET_ID: { type: "string" },
+    RELAYER_MNEMONIC_SECRET_ID: { type: "string" },
   },
 };
 

--- a/src/get-relayer-address.ts
+++ b/src/get-relayer-address.ts
@@ -1,0 +1,26 @@
+import { Account } from "viem";
+
+import { config } from "./config";
+import { deriveRelayerAccount } from "./utils";
+import getSecret from "./get-secret";
+
+async function main() {
+  if (process.argv.length < 3) {
+    console.log("Usage: npm run get:relayer:address -- <ratefeed>");
+    console.log("e.g. npm run get:relayer:address -- PHP/USD");
+    process.exit(1);
+  }
+
+  const ratefeed = process.argv[2];
+
+  try {
+    const mnemonic = await getSecret(config.RELAYER_MNEMONIC_SECRET_ID);
+    const account: Account = deriveRelayerAccount(mnemonic, ratefeed);
+    console.log(`Derived address for ${ratefeed}: ${account.address}`);
+  } catch (error) {
+    console.error("Error deriving account:", error);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/src/get-relayer-signer.ts
+++ b/src/get-relayer-signer.ts
@@ -16,7 +16,7 @@ async function main() {
   try {
     const mnemonic = await getSecret(config.RELAYER_MNEMONIC_SECRET_ID);
     const account: Account = deriveRelayerAccount(mnemonic, ratefeed);
-    console.log(`Derived address for ${ratefeed}: ${account.address}`);
+    console.log(`Derived signer account for ${ratefeed}: ${account.address}`);
   } catch (error) {
     console.error("Error deriving account:", error);
     process.exit(1);

--- a/src/get-relayer-signer.ts
+++ b/src/get-relayer-signer.ts
@@ -18,7 +18,7 @@ async function main() {
     const account: Account = deriveRelayerAccount(mnemonic, ratefeed);
     console.log(`Derived signer account for ${ratefeed}: ${account.address}`);
   } catch (error) {
-    console.error("Error deriving account:", error);
+    console.error("Error deriving relayer signer account:", error);
     process.exit(1);
   }
 }

--- a/src/get-relayer-signer.ts
+++ b/src/get-relayer-signer.ts
@@ -6,8 +6,8 @@ import getSecret from "./get-secret";
 
 async function main() {
   if (process.argv.length < 3) {
-    console.log("Usage: npm run get:relayer:address -- <ratefeed>");
-    console.log("e.g. npm run get:relayer:address -- PHP/USD");
+    console.log("Usage: npm run get:relayer:signer -- <ratefeed>");
+    console.log("e.g. npm run get:relayer:signer -- PHP/USD");
     process.exit(1);
   }
 

--- a/src/get-secret.ts
+++ b/src/get-secret.ts
@@ -1,5 +1,5 @@
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
-import config from "./config.js";
+import config from "./config";
 
 /**
  * Load a secret from Secret Manager

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,6 +19,7 @@ export function deriveRelayerAccount(
     .digest("hex")
     .slice(0, 8);
   // Index must be between 0 and 2^31 - 1 for non-hardened keys (BIP32)
+  // See https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#extended-keys
   const accountIndex = parseInt(hash, 16) % 2147483648;
 
   return mnemonicToAccount(mnemonic, { accountIndex });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,25 @@
+import { HDAccount, mnemonicToAccount } from "viem/accounts";
+
+import { createHash } from "crypto";
+
+/**
+ * Given a mnemonic and a rate feed name, returns the derived account that will be used
+ * for relaying transactions.
+ * @param mnemonic The mnemonic to derive the account from
+ * @param rateFeedName The name of the rate feed
+ * @returns The derived account
+ */
+export function deriveRelayerAccount(
+  mnemonic: string,
+  rateFeedName: string,
+): HDAccount {
+  // Create a deterministic index based on the rate feed
+  const hash = createHash("sha256")
+    .update(rateFeedName)
+    .digest("hex")
+    .slice(0, 8);
+  // Index must be between 0 and 2^31 - 1 for non-hardened keys (BIP32)
+  const accountIndex = parseInt(hash, 16) % 2147483648;
+
+  return mnemonicToAccount(mnemonic, { accountIndex });
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,7 +20,7 @@ export function deriveRelayerAccount(
     .slice(0, 8);
   // Index must be between 0 and 2^31 - 1 for non-hardened keys (BIP32)
   // See https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#extended-keys
-  const accountIndex = parseInt(hash, 16) % 2147483648;
+  const accountIndex = parseInt(hash, 16) % 2 ** 31;
 
   return mnemonicToAccount(mnemonic, { accountIndex });
 }


### PR DESCRIPTION
This changes the use of a single private key for all relayers to a mnemonic that can be used to derive a unique account for each rate feed. This is because we were getting nonce errors when trying to relay multiple txs for different relayers at the same time.

I also added a script that can be used for getting the address for a rate feed: `npm run get:relayer:address`