### PR TITLE
feat: off-chain monitoring

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.3
+  version: 1.22.4
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
@@ -23,7 +23,7 @@ lint:
     - markdown-table-prettify
   enabled:
     - actionlint@1.7.1
-    - checkov@3.2.236
+    - checkov@3.2.242
     - dotenv-linter@3.3.0
     - dustilock@1.2.0
     - eslint@9.9.1
@@ -41,7 +41,7 @@ lint:
     - terraform@1.1.0
     - terrascan@1.19.1
     - tflint@0.53.0
-    - trufflehog@3.81.9
+    - trufflehog@3.81.10
     - yamllint@1.35.1
 actions:
   disabled:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@
    # Note that the above secret only exists in the oracle-relayer-prod GCP project
    discord_webhook_url_prod      = "<prod-webhook-url>"
 
-   # Get it from our VictorOps by and `Integrations` > `Stackdriver` and copying the URL. The routing key can be founder under the settings tab
+   # Get it from our VictorOps by going to `Integrations` > `Stackdriver` and copying the URL. The routing key can be found under the settings tab
    victorops_webhook_url   = "<victorops-webhook-url>/<victorops-routing-key>"
 
    ```

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@
    # Note that the mnemonic is the same for both the staging and prod environments.
    # To fetch secrets, you'll need the `Secret Manager Secret Accessor` IAM role assigned to your Google Cloud Account
    relayer_mnemonic      = "<relayer-mnemonic>"
+
+   # Get it via `gcloud secrets versions access latest --secret discord_webhook_url_staging`
+   # Note that the above secret only exists in the oracle-relayer-staging GCP project
+   discord_webhook_url_staging      = "<staging-webhook-url>"
+
+   # Get it via `gcloud secrets versions access latest --secret discord_webhook_url_prod`
+   # Note that the above secret only exists in the oracle-relayer-prod GCP project
+   discord_webhook_url_prod      = "<prod-webhook-url>"
+
+   # Get it from our VictorOps by and `Integrations` > `Stackdriver` and copying the URL. The routing key can be founder under the settings tab
+   victorops_webhook_url   = "<victorops-webhook-url>/<victorops-routing-key>"
+
    ```
 
 1. Verify that everything works

--- a/infra/cloud_function.tf
+++ b/infra/cloud_function.tf
@@ -25,7 +25,7 @@ resource "google_cloudfunctions2_function" "relay" {
 
     environment_variables = {
       GCP_PROJECT_ID                = module.oracle_relayer.project_id
-      DISCORD_WEBHOOK_URL_SECRET_ID = var.discord_webhook_url_secret_id
+      DISCORD_WEBHOOK_URL_SECRET_ID = google_secret_manager_secret.discord_webhook_url.secret_id
       RELAYER_MNEMONIC_SECRET_ID    = google_secret_manager_secret.relayer_mnemonic.secret_id
       # Logs execution ID for easier debugging => https://cloud.google.com/functions/docs/monitoring/logging#viewing_runtime_logs
       LOG_EXECUTION_ID = "true"

--- a/infra/cloud_function.tf
+++ b/infra/cloud_function.tf
@@ -24,8 +24,9 @@ resource "google_cloudfunctions2_function" "relay" {
     timeout_seconds       = 60
 
     environment_variables = {
-      GCP_PROJECT_ID             = module.oracle_relayer.project_id
-      RELAYER_MNEMONIC_SECRET_ID = google_secret_manager_secret.relayer_mnemonic.secret_id
+      GCP_PROJECT_ID                = module.oracle_relayer.project_id
+      DISCORD_WEBHOOK_URL_SECRET_ID = var.discord_webhook_url_secret_id
+      RELAYER_MNEMONIC_SECRET_ID    = google_secret_manager_secret.relayer_mnemonic.secret_id
       # Logs execution ID for easier debugging => https://cloud.google.com/functions/docs/monitoring/logging#viewing_runtime_logs
       LOG_EXECUTION_ID = "true"
       NODE_ENV         = terraform.workspace == "staging" ? "development" : "production"

--- a/infra/local-dotenv-file.tf
+++ b/infra/local-dotenv-file.tf
@@ -2,6 +2,7 @@ resource "local_file" "env_file" {
   filename = "${path.module}/../.env"
   content  = <<-EOT
     GCP_PROJECT_ID=${module.oracle_relayer.project_id}
+    DISCORD_WEBHOOK_URL=${var.discord_webhook_url}
     RELAYER_MNEMONIC_SECRET_ID=${var.relayer_mnemonic_secret_id}-${terraform.workspace}
   EOT
 }

--- a/infra/local-dotenv-file.tf
+++ b/infra/local-dotenv-file.tf
@@ -3,6 +3,7 @@ resource "local_file" "env_file" {
   content  = <<-EOT
     GCP_PROJECT_ID=${module.oracle_relayer.project_id}
     DISCORD_WEBHOOK_URL=${var.discord_webhook_url}
+    DISCORD_WEBHOOK_URL_SECRET_ID=${var.discord_webhook_url_secret_id}
     RELAYER_MNEMONIC_SECRET_ID=${var.relayer_mnemonic_secret_id}
   EOT
 }

--- a/infra/local-dotenv-file.tf
+++ b/infra/local-dotenv-file.tf
@@ -2,8 +2,9 @@ resource "local_file" "env_file" {
   filename = "${path.module}/../.env"
   content  = <<-EOT
     GCP_PROJECT_ID=${module.oracle_relayer.project_id}
-    DISCORD_WEBHOOK_URL=${var.discord_webhook_url}
-    DISCORD_WEBHOOK_URL_SECRET_ID=${var.discord_webhook_url_secret_id}
+    DISCORD_WEBHOOK_URL_STAGING=${var.discord_webhook_url_staging}
+    DISCORD_WEBHOOK_URL_PROD=${var.discord_webhook_url_prod}
+    DISCORD_WEBHOOK_URL_SECRET_ID=${var.discord_webhook_url_secret_id}-${terraform.workspace}
     RELAYER_MNEMONIC_SECRET_ID=${var.relayer_mnemonic_secret_id}
   EOT
 }

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -55,7 +55,7 @@ resource "google_monitoring_alert_policy" "successful_relay_policy" {
   enabled      = true
 
   documentation {
-    content = "No successful relay events have been logged in the last 30 minutes"
+    content = "No successful relay events for $${metric.label.ratefeed} in the past 30 minutes"
   }
 
   conditions {

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -27,7 +27,7 @@ resource "google_logging_metric" "successful_relay_count" {
 # Discord notification channel for info-only alerts
 resource "google_monitoring_notification_channel" "discord_channel" {
   project      = module.oracle_relayer.project_id
-  display_name = "Discord ${terraform.workspace}-oracle-relayers"
+  display_name = "Discord #${terraform.workspace}-oracle-relayers"
   type         = "webhook_tokenauth"
 
   labels = {

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -1,0 +1,128 @@
+# Creates a metric that counts the number of log entries containing 'Relay succeeded' in the relay cloud function.
+resource "google_logging_metric" "successful_relay_count" {
+  project     = module.oracle_relayer.project_id
+  name        = "successful_relay_count"
+  description = "Number of log entries containing 'Relay succeeded' in the relay cloud function"
+  filter      = <<EOF
+    severity=DEFAULT
+    SEARCH("`[Relay succeeded]`")
+    resource.labels.service_name="${google_cloudfunctions2_function.relay.name}"
+  EOF
+}
+
+# Creates a metric that counts the number of log entries containing 'price is invalid' in the relay cloud function.
+resource "google_logging_metric" "invalid_price_count" {
+  project     = module.oracle_relayer.project_id
+  name        = "invalid_price_count"
+  description = "Number of log entries containing 'price is invalid' in the relay cloud function"
+  filter      = <<EOF
+    severity=DEFAULT
+    SEARCH("`[price is invalid]`")
+    resource.labels.service_name="${google_cloudfunctions2_function.relay.name}"
+  EOF
+}
+
+# Creates a notification channel where alerts will be sent based on the alert policy below.
+resource "google_monitoring_notification_channel" "discord_channel" {
+  project      = module.oracle_relayer.project_id
+  display_name = "Discord Oracle Relayer"
+  type         = "webhook_tokenauth"
+
+  labels = {
+    url = var.discord_webhook_url
+  }
+}
+
+# Creates a notification channel where alerts will be sent based on the alert policy below.
+resource "google_monitoring_notification_channel" "victorops_channel" {
+  project      = module.oracle_relayer.project_id
+  display_name = "Splunk (VictorOps)"
+  type         = "webhook_tokenauth"
+
+  labels = {
+    url = var.victorops_webhook_url
+  }
+}
+
+# Creates an alert policy that triggers when no successful relay logs have been received in the last 6 hours,
+# and sends a notification to the channel above.
+resource "google_monitoring_alert_policy" "successful_relay_policy" {
+  project      = module.oracle_relayer.project_id
+  display_name = "no-successful-relay-logs"
+  combiner     = "OR"
+  enabled      = true
+
+  documentation {
+    content = "No successful relay events have been logged in the last 6 hours"
+  }
+
+  conditions {
+    display_name = "No successful relay logs in 6 hours"
+
+    condition_threshold {
+      filter = <<EOF
+        resource.type = "cloud_run_revision" AND
+        metric.type   = "logging.googleapis.com/user/${google_logging_metric.successful_relay_count.name}"
+      EOF
+
+      duration        = "300s" # Re-test the condition every 5 minutes
+      comparison      = "COMPARISON_LT"
+      threshold_value = 1
+
+      aggregations {
+        alignment_period     = "3600s" # 1 hour
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.victorops_channel.id]
+  severity              = "CRITICAL"
+}
+
+
+# Creates an alert policy that triggers when more than 1 invalid price logs have been received in the last hour,
+# and sends a notification to the channel above.
+resource "google_monitoring_alert_policy" "invalid_price_policy" {
+  project      = module.oracle_relayer.project_id
+  display_name = "invalid-price-logs"
+  combiner     = "OR"
+  enabled      = true
+
+  documentation {
+    content = "More than 1 invalid price events have been logged in the last hour"
+  }
+
+  conditions {
+    display_name = "More than 1 invalid price logs in 1 hour"
+
+    condition_threshold {
+      filter = <<EOF
+        resource.type = "cloud_run_revision" AND
+        metric.type   = "logging.googleapis.com/user/${google_logging_metric.invalid_price_count.name}"
+      EOF
+
+      duration        = "300s" # Re-test the condition every 5 minutes
+      comparison      = "COMPARISON_GT"
+      threshold_value = 1
+
+      aggregations {
+        alignment_period     = "3600s" # 1 hour
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.discord_channel.id]
+  severity              = "INFO"
+}

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -27,7 +27,7 @@ resource "google_logging_metric" "successful_relay_count" {
 # Discord notification channel for info-only alerts
 resource "google_monitoring_notification_channel" "discord_channel" {
   project      = module.oracle_relayer.project_id
-  display_name = "Discord #relayer-alerts"
+  display_name = "Discord ${terraform.workspace}-oracle-relayers"
   type         = "webhook_tokenauth"
 
   labels = {

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -4,9 +4,9 @@ resource "google_logging_metric" "successful_relay_count" {
   name        = "successful_relay_count"
   description = "Number of log entries containing 'Relay succeeded' in the relay cloud function"
   filter      = <<EOF
-    severity=DEFAULT
+    severity>=DEFAULT
     SEARCH("`Relay succeeded`")
-    resource.labels.service_name="${google_cloudfunctions2_function.relay.name}"
+    resource.labels.function_name="${google_cloudfunctions2_function.relay.name}"
   EOF
 }
 
@@ -49,7 +49,7 @@ resource "google_monitoring_alert_policy" "successful_relay_policy" {
 
     condition_threshold {
       filter = <<EOF
-        resource.type = "cloud_run_revision" AND
+        resource.type = "cloud_function" AND
         metric.type   = "logging.googleapis.com/user/${google_logging_metric.successful_relay_count.name}"
       EOF
 

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -51,7 +51,7 @@ resource "google_monitoring_notification_channel" "victorops_channel" {
 resource "google_monitoring_alert_policy" "successful_relay_policy" {
   project      = module.oracle_relayer.project_id
   display_name = "no-successful-relay-logs"
-  combiner     = "OR"
+  combiner     = "OR" # Not used in practice because we only have one condition, but it's required by the API
   enabled      = true
 
   documentation {

--- a/infra/secret-manager.tf
+++ b/infra/secret-manager.tf
@@ -14,7 +14,7 @@ resource "google_secret_manager_secret_version" "relayer_mnemonic" {
 
 resource "google_secret_manager_secret" "discord_webhook_url" {
   project   = module.oracle_relayer.project_id
-  secret_id = var.discord_webhook_url_secret_id
+  secret_id = "${var.discord_webhook_url_secret_id}-${terraform.workspace}"
 
   replication {
     auto {}
@@ -23,5 +23,5 @@ resource "google_secret_manager_secret" "discord_webhook_url" {
 
 resource "google_secret_manager_secret_version" "discord_webhook_url" {
   secret      = google_secret_manager_secret.discord_webhook_url.id
-  secret_data = var.discord_webhook_url
+  secret_data = terraform.workspace == "prod" ? var.discord_webhook_url_prod : var.discord_webhook_url_staging
 }

--- a/infra/secret-manager.tf
+++ b/infra/secret-manager.tf
@@ -11,3 +11,20 @@ resource "google_secret_manager_secret_version" "relayer_mnemonic" {
   secret      = google_secret_manager_secret.relayer_mnemonic.id
   secret_data = var.relayer_mnemonic
 }
+
+# Creates a new secret for the Discord webhook URL.
+# Terraform will try to look up the webhook URL from terraform.tfvars,
+# and if it can't find it locally it will prompt the user to enter it manually.
+resource "google_secret_manager_secret" "discord_webhook_url" {
+  project   = module.oracle_relayer.project_id
+  secret_id = var.discord_webhook_url_secret_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "discord_webhook_url" {
+  secret      = google_secret_manager_secret.discord_webhook_url.id
+  secret_data = var.discord_webhook_url
+}

--- a/infra/secret-manager.tf
+++ b/infra/secret-manager.tf
@@ -12,9 +12,6 @@ resource "google_secret_manager_secret_version" "relayer_mnemonic" {
   secret_data = var.relayer_mnemonic
 }
 
-# Creates a new secret for the Discord webhook URL.
-# Terraform will try to look up the webhook URL from terraform.tfvars,
-# and if it can't find it locally it will prompt the user to enter it manually.
 resource "google_secret_manager_secret" "discord_webhook_url" {
   project   = module.oracle_relayer.project_id
   secret_id = var.discord_webhook_url_secret_id

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -46,11 +46,19 @@ variable "discord_webhook_url_secret_id" {
 }
 
 # You can look this up either on the Discord Channel settings, or fetch it from Secret Manager via:
-#  `gcloud secrets versions access latest --secret discord-webhook-url`
-variable "discord_webhook_url" {
+#  `gcloud secrets versions access latest --secret discord-webhook-url-staging`
+variable "discord_webhook_url_staging" {
   type      = string
   sensitive = true
 }
+
+# You can look this up either on the Discord Channel settings, or fetch it from Secret Manager via:
+#  `gcloud secrets versions access latest --secret discord-webhook-url-prod`
+variable "discord_webhook_url_prod" {
+  type      = string
+  sensitive = true
+}
+
 
 
 #####################################################################################

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -30,6 +30,29 @@ variable "relayer_mnemonic" {
   sensitive = true
 }
 
+# Webhook URL to send monitoring alerts from within GCP Monitoring
+# You can find this URL in Victorops by going to "Integrations" -> "Stackdriver".
+# The routing key can be found under "Settings" -> "Routing Keys"
+variable "victorops_webhook_url" {
+  type      = string
+  sensitive = true
+}
+
+# You can look this up via:
+#  `gcloud secrets list`
+variable "discord_webhook_url_secret_id" {
+  type    = string
+  default = "discord-webhook-url"
+}
+
+# You can look this up either on the Discord Channel settings, or fetch it from Secret Manager via:
+#  `gcloud secrets versions access latest --secret discord-webhook-url`
+variable "discord_webhook_url" {
+  type      = string
+  sensitive = true
+}
+
+
 #####################################################################################
 # The below are mainly kept in vars so we can read them easier in the shell scripts #
 #####################################################################################

--- a/package-lock.json
+++ b/package-lock.json
@@ -1529,20 +1529,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "dev": true,
@@ -2545,9 +2531,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.20.0.tgz",
-      "integrity": "sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2561,7 +2547,7 @@
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
         "merge-descriptors": "1.0.3",
@@ -2570,11 +2556,11 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.19.0",
-        "serve-static": "1.16.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -2675,17 +2661,26 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
         "statuses": "2.0.1",
         "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -4001,7 +3996,8 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -4173,10 +4169,11 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "license": "BSD-3-Clause",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -4458,45 +4455,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/serve-static": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.0.tgz",
-      "integrity": "sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/serve-static/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/serve-static/node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-function-length": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/functions-framework": "^3.4.2",
         "@google-cloud/logging-winston": "^6.0.0",
         "@google-cloud/secret-manager": "^5.6.0",
+        "discord.js": "^14.16.1",
         "env-schema": "^6.0.0",
         "viem": "^2.18.8",
         "winston": "^3.14.1"
@@ -78,6 +79,130 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.9.0.tgz",
+      "integrity": "sha512-0zx8DePNVvQibh5ly5kCEei5wtPBIUbSoE9n+91Rlladz4tgtFbJ36PZMxxZrTEOQ7AHMZ/b0crT/0fCy6FTKg==",
+      "dependencies": {
+        "@discordjs/formatters": "^0.5.0",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "0.37.97",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.5.0.tgz",
+      "integrity": "sha512-98b3i+Y19RFq1Xke4NkVY46x8KjJQjldHUuEbCqMvp1F5Iq9HgnGpu91jOi/Ufazhty32eRsKnnzS8n4c+L93g==",
+      "dependencies": {
+        "discord-api-types": "0.37.97"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0.tgz",
+      "integrity": "sha512-Xb2irDqNcq+O8F0/k/NaDp7+t091p+acb51iA4bCKfIn+WFWd6HrNvcsSbMMxIR9NjcMZS6NReTKygqiQN+ntw==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "0.37.97",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.19.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
+      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.1.tgz",
+      "integrity": "sha512-PZ+vLpxGCRtmr2RMkqh8Zp+BenUaJqlS6xhgWKEZcgC/vfHLEzpHtKkB0sl3nZWpwtcKk6YWy+pU3okL2I97FA==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
+        "tslib": "^2.6.2",
+        "ws": "^8.16.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/discord-api-types": {
+      "version": "0.37.83",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
+      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -625,6 +750,36 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
+      "integrity": "sha512-x7zadcfJGxFka1Q3f8gCts1F0xMwCKbZweM85xECGI0hBTeIZJGGCrHgLggihBoprlQ/hBmDR5LKfIPqnmHM3w==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@scure/base": {
       "version": "1.1.7",
       "license": "MIT",
@@ -816,6 +971,14 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.0.1",
@@ -1081,6 +1244,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/abitype": {
@@ -1740,6 +1912,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.37.97",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.97.tgz",
+      "integrity": "sha512-No1BXPcVkyVD4ZVmbNgDKaBoqgeQ+FJpzZ8wqHkfmBnTZig1FcH3iPPersiK1TUIAzgClh2IvOuVUYfcWLQAOA=="
+    },
+    "node_modules/discord.js": {
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.16.1.tgz",
+      "integrity": "sha512-/diX4shp3q1F3EySGQbQl10el+KIpffLSOJdtM35gGV7zw2ED7rKbASKJT7UIR9L/lTd0KtNenZ/h739TN7diA==",
+      "dependencies": {
+        "@discordjs/builders": "^1.9.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.5.0",
+        "@discordjs/rest": "^2.4.0",
+        "@discordjs/util": "^1.1.1",
+        "@discordjs/ws": "1.1.1",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "0.37.97",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "tslib": "^2.6.3",
+        "undici": "6.19.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/dot-prop": {
@@ -3341,6 +3543,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -3357,6 +3564,11 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
     "node_modules/logform": {
       "version": "2.6.1",
@@ -3391,6 +3603,11 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+      "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -4724,6 +4941,16 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4794,6 +5021,14 @@
       "version": "2.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@google-cloud/functions-framework": "^3.4.2",
     "@google-cloud/logging-winston": "^6.0.0",
     "@google-cloud/secret-manager": "^5.6.0",
+    "discord.js": "^14.16.1",
     "env-schema": "^6.0.0",
     "viem": "^2.18.8",
     "winston": "^3.14.1"

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,8 +9,12 @@ export interface Env {
 
 const schema: JSONSchemaType<Env> = {
   type: "object",
-  required: ["GCP_PROJECT_ID", "NODE_ENV", "DISCORD_WEBHOOK_URL_SECRET_ID",
-    "RELAYER_MNEMONIC_SECRET_ID"],
+  required: [
+    "GCP_PROJECT_ID",
+    "NODE_ENV",
+    "DISCORD_WEBHOOK_URL_SECRET_ID",
+    "RELAYER_MNEMONIC_SECRET_ID",
+  ],
   properties: {
     GCP_PROJECT_ID: { type: "string" },
     DISCORD_WEBHOOK_URL_SECRET_ID: { type: "string" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,13 +4,16 @@ export interface Env {
   GCP_PROJECT_ID: string;
   NODE_ENV: string;
   RELAYER_MNEMONIC_SECRET_ID: string;
+  DISCORD_WEBHOOK_URL_SECRET_ID: string;
 }
 
 const schema: JSONSchemaType<Env> = {
   type: "object",
-  required: ["GCP_PROJECT_ID", "NODE_ENV", "RELAYER_MNEMONIC_SECRET_ID"],
+  required: ["GCP_PROJECT_ID", "NODE_ENV", "DISCORD_WEBHOOK_URL_SECRET_ID",
+    "RELAYER_MNEMONIC_SECRET_ID"],
   properties: {
     GCP_PROJECT_ID: { type: "string" },
+    DISCORD_WEBHOOK_URL_SECRET_ID: { type: "string" },
     NODE_ENV: { type: "string" },
     RELAYER_MNEMONIC_SECRET_ID: { type: "string" },
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,23 +1,23 @@
 import { JSONSchemaType, envSchema } from "env-schema";
 
 export interface Env {
+  DISCORD_WEBHOOK_URL_SECRET_ID: string;
   GCP_PROJECT_ID: string;
   NODE_ENV: string;
   RELAYER_MNEMONIC_SECRET_ID: string;
-  DISCORD_WEBHOOK_URL_SECRET_ID: string;
 }
 
 const schema: JSONSchemaType<Env> = {
   type: "object",
   required: [
+    "DISCORD_WEBHOOK_URL_SECRET_ID",
     "GCP_PROJECT_ID",
     "NODE_ENV",
-    "DISCORD_WEBHOOK_URL_SECRET_ID",
     "RELAYER_MNEMONIC_SECRET_ID",
   ],
   properties: {
-    GCP_PROJECT_ID: { type: "string" },
     DISCORD_WEBHOOK_URL_SECRET_ID: { type: "string" },
+    GCP_PROJECT_ID: { type: "string" },
     NODE_ENV: { type: "string" },
     RELAYER_MNEMONIC_SECRET_ID: { type: "string" },
   },

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -178,7 +178,7 @@ async function handleContractFunctionRevertError(
     }
     case "InvalidPrice": {
       logger.error("Relay failed. Chainlink price is invalid");
-      await sendDiscordNotification(rateFeedName);
+      await sendDiscordNotification(rateFeedName, revertError);
       break;
     }
     case "Error": {

--- a/src/send-discord-notification.ts
+++ b/src/send-discord-notification.ts
@@ -1,0 +1,13 @@
+import { WebhookClient } from "discord.js";
+import config from "./config";
+import getSecret from "./get-secret.js";
+
+export default async function sendDiscordNotification(rateFeedName: string) {
+  const discordWebhookClient = new WebhookClient({
+    url: await getSecret(config.DISCORD_WEBHOOK_URL_SECRET_ID),
+  });
+
+  await discordWebhookClient.send(
+    `🚨 Invalid price error while relaying ${rateFeedName}`,
+  );
+}

--- a/src/send-discord-notification.ts
+++ b/src/send-discord-notification.ts
@@ -1,13 +1,25 @@
+import { ContractFunctionRevertedError } from "viem";
 import { WebhookClient } from "discord.js";
+
 import config from "./config";
 import getSecret from "./get-secret.js";
 
-export default async function sendDiscordNotification(rateFeedName: string) {
+export default async function sendDiscordNotification(
+  rateFeedName: string,
+  err: ContractFunctionRevertedError,
+) {
   const discordWebhookClient = new WebhookClient({
     url: await getSecret(config.DISCORD_WEBHOOK_URL_SECRET_ID),
   });
 
-  await discordWebhookClient.send(
-    `🚨 Invalid price error while relaying ${rateFeedName}`,
-  );
+  await discordWebhookClient.send({
+    content: `🚨 Invalid price error while relaying ${rateFeedName}`,
+    embeds: [
+      {
+        title: "Error Details",
+        description: JSON.stringify(err),
+        color: 0xff0000, // Red color for error
+      },
+    ],
+  });
 }


### PR DESCRIPTION
This implements off-chain monitoring according to the spec, which consists of two things:

1. Sending an `info` alert whenever an invalid price error occurs. This is fired directly from the code using `discord.js` instead of using the discord dispatcher function that we discussed at some point, to keep things simple

2. The creation of a log based metric that looks a successful relay logs per rate feed, and sends an on-call alert in case none have been seen for the past 30 minutes (as a backup to the aegis on-chain monitoring).

I deployed this to both envs and tested than both alerts work.

Other non-related changes in this PR:

- Fixed a vuln reported by the CI using `npm fix`
> package-lock.json:4468:0
 4468:0  medium  'send' vulnerable to template injection that can lead to XSS. Current   osv-scanner/GHSA-m6fv-jmcg-4jfg
                 version is vulnerable: 0.18.0. 
