### PR TITLE
Added aegis export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 - [Debugging Local Problems](#debugging-local-problems)
 - [npm tasks and dev scripts](#npm-tasks-and-dev-scripts)
 - [Updating the Cloud Function](#updating-the-cloud-function)
+- [Deploying a new Oracle Relayer](#deploying-a-new-oracle-relayer)
+- [Aegis Export for Monitoring Relayers](#aegis-export-for-monitoring-relayers)
 
 ## Local Setup
 
@@ -189,3 +191,21 @@ You have two options to deploy the Cloud Function code, `terraform` or `gcloud` 
      - Will lead to inconsistent terraform state (because terraform is tracking the function source code and its version)
      - Different commands to remember when updating infra components vs cloud function source code
      - Will only work for updating a pre-existing cloud function's code, will fail for a first-time deploy
+
+## Deploying a new Oracle Relayer
+
+1. Deploy the new relayer contracts via the [relayer factory](https://github.com/mento-protocol/mento-core/blob/develop/contracts/oracles/ChainlinkRelayerFactory.sol). Exemplary deployment scripts can be found in the [MU07 Deployment Scripts](https://github.com/mento-protocol/mento-deployment/blob/main/script/upgrades/MU07/deploy/MU07-Deploy-ChainlinkRelayers.sol)
+1. Ensure the new relayers have been whitelisted in SortedOracles on both Alfajores and Mainnet (otherwise all relay() transactions will fail)
+1. Add the addresses of the deployed relayers to [relayer_addresses.json](./infra/relayer_addresses.json) (alfajores relayers under `staging`, mainnet relayers under `prod`)
+1. Run `npm run deploy:staging` and/or `npm run deploy:prod` to create GCP cloud scheduler jobs for the new relayers
+1. [Add the new relayers to aegis for monitoring](#aegis-export-for-monitoring-relayers)
+
+## Aegis Export for Monitoring Relayers
+
+1. Run `npm run aegis:export` to print out an aegis config template in your local CLI
+1. Copy the relevant sections for the relayers you want to add to aegis
+1. Paste them into [aegis' config.local.yaml](https://github.com/mento-protocol/aegis/blob/main/config.local.yaml)
+1. Run aegis in dev mode via `npm run dev`, check that there are no errors in the log outputs
+1. Copy your changes to config.local.yaml over into [config.yaml](https://github.com/mento-protocol/aegis/blob/main/config.yaml)
+1. Submit a PR with your changes
+1. After successful code review, deploy your changes via `npm run deploy` in aegis

--- a/bin/aegis-export.sh
+++ b/bin/aegis-export.sh
@@ -5,11 +5,16 @@ set -u          # Treat unset variables as an error when substituting
 
 # If .env exists, source it
 if [[ -f .env ]]; then
+	# We know at this point that .env exists, so we can safely source it
+	# trunk-ignore(shellcheck/SC1091)
 	source .env
 	# Check if RELAYER_MNEMONIC_SECRET_ID is set, if not, regenerate .env
 	if [[ -z ${RELAYER_MNEMONIC_SECRET_ID} ]]; then
 		echo 'Env var RELAYER_MNEMONIC_SECRET_ID not found. Regenerating .env...'
 		npm run generate:env
+
+		# We know at this point that .env exists because the npm task created it (or failed with an error), so we can safely source it
+		# trunk-ignore(shellcheck/SC1091)
 		source .env
 	fi
 

--- a/bin/aegis-export.sh
+++ b/bin/aegis-export.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e          # Fail on any error
+set -o pipefail # Ensure piped commands propagate exit codes properly
+set -u          # Treat unset variables as an error when substituting
+
+# If .env exists, source it
+if [[ -f .env ]]; then
+	source .env
+	# Check if RELAYER_MNEMONIC_SECRET_ID is set, if not, regenerate .env
+	if [[ -z ${RELAYER_MNEMONIC_SECRET_ID} ]]; then
+		echo 'Env var RELAYER_MNEMONIC_SECRET_ID not found. Regenerating .env...'
+		npm run generate:env
+		source .env
+	fi
+
+# If not, regenerate .env to ensure RELAYER_MNEMONIC_SECRET_ID is set
+else
+	echo 'Env var RELAYER_MNEMONIC_SECRET_ID not found. Regenerating .env...'
+	npm run generate:env
+fi
+
+# Print out all signer wallets for all relayers in an aegis-compatible format (so monitoring additional signer wallets becomes as easy as copy-pasting)
+echo "Generating aegis-compatible signer wallet export..."
+NODE_ENV=development npx ts-node ./src/aegis-export.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1335,8 +1335,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "license": "MIT",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -1346,7 +1347,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -1354,6 +1355,20 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/brace-expansion": {
@@ -2302,7 +2317,8 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2327,35 +2343,36 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "license": "MIT",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.20.0.tgz",
+      "integrity": "sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "finalhandler": "1.2.0",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
         "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.0",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -2364,6 +2381,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/extend": {
@@ -2544,7 +2569,8 @@
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3374,8 +3400,12 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "license": "MIT"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3408,7 +3438,8 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "bin": {
         "mime": "cli.js"
       },
@@ -3793,8 +3824,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "license": "MIT"
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -3958,7 +3990,8 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4180,8 +4213,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "license": "MIT",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -4203,16 +4237,46 @@
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "license": "MIT",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.0.tgz",
+      "integrity": "sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==",
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
         "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static/node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
       },
       "engines": {
         "node": ">= 0.8.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Mento Labs <eng@mentolabs.xyz>",
   "main": "dist/index.js",
   "scripts": {
+    "aegis:export": "./bin/aegis-export.sh",
     "build": "rimraf dist && tsc",
     "cache:clear": "./bin/get-project-vars.sh --invalidate-cache",
     "deploy:function:prod": "./bin/deploy-via-gcloud.sh prod",
@@ -16,7 +17,7 @@
     "destroy:staging": "./bin/destroy-project.sh staging",
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'npm run build && npm run start'",
     "gcp-build": "npm run build",
-    "generate:env": "terraform -chdir=infra apply -target=local_file.env_file",
+    "generate:env": "terraform -chdir=infra apply -target=local_file.env_file -auto-approve",
     "get:relayer:signer": "NODE_ENV=development npx ts-node ./src/get-relayer-signer.ts",
     "logs": "npm run logs:function:staging",
     "logs:function:prod": "./bin/get-function-logs.sh prod",

--- a/src/aegis-export.ts
+++ b/src/aegis-export.ts
@@ -1,0 +1,105 @@
+import type { Address } from "viem";
+import RelayerAddressesJson from "../infra/relayer_addresses.json";
+import { config } from "./config";
+import getSecret from "./get-secret";
+import { deriveRelayerAccount, toRateFeedId } from "./utils";
+
+const RelayerAddresses = RelayerAddressesJson as {
+  [env in "staging" | "prod"]: Record<string, Address>;
+};
+
+type Environment = keyof typeof RelayerAddresses;
+type RateFeed<T extends Environment> = keyof (typeof RelayerAddresses)[T];
+
+interface Relayer {
+  env: Environment;
+  rateFeedId: Address;
+  rateFeed: string;
+  relayerAddress: Address;
+  signerAddress: Address;
+}
+
+async function aegisExport() {
+  try {
+    const mnemonic = await getSecret(config.RELAYER_MNEMONIC_SECRET_ID);
+
+    const allRelayers = (
+      Object.entries(RelayerAddresses) as [
+        Environment,
+        (typeof RelayerAddresses)[Environment],
+      ][]
+    ).flatMap(([env, rateFeeds]) =>
+      Object.keys(rateFeeds).map((rateFeed) =>
+        createRelayer(env, rateFeed, mnemonic),
+      ),
+    );
+
+    const uniqueRelayers = Array.from(
+      new Map(
+        allRelayers.map((relayer) => [relayer.rateFeedId, relayer]),
+      ).values(),
+    );
+
+    const configYaml = generateConfigYaml(uniqueRelayers);
+
+    console.log("\x1b[1m" + configYaml + "\x1b[0m");
+  } catch (error) {
+    console.error("Error occurred during aegis export:", error);
+    process.exit(1);
+  }
+}
+
+const createRelayer = <T extends Environment>(
+  env: T,
+  rateFeed: RateFeed<T>,
+  mnemonic: string,
+): Relayer => {
+  // Type assertion (as string) is safe here because we know that the keys of our RelayerAddresses object are always strings
+  const formattedRateFeed = (rateFeed as string).replace("_", "").toUpperCase();
+  return {
+    env,
+    rateFeed: formattedRateFeed,
+    rateFeedId: toRateFeedId(`relayed:${formattedRateFeed}`),
+    signerAddress: deriveRelayerAccount(mnemonic, rateFeed as string).address,
+    relayerAddress: RelayerAddresses[env][rateFeed] as Address,
+  };
+};
+
+function generateConfigYaml(relayers: Relayer[]): string {
+  return `
+###############################################################
+# Exemplary aegis config.yaml with all relevant values to add #
+###############################################################
+
+global:
+  vars:
+    # Rate Feed IDs
+${relayers.map(({ rateFeed, rateFeedId }) => `    'relayed:${rateFeed}': '${rateFeedId}'`).join("\n")}
+
+    # Relayer Signer Wallets
+${relayers.map(({ rateFeed, signerAddress }) => `    RelayerSigner${rateFeed}: '${signerAddress}'`).join("\n")}
+
+metrics:
+  # Checks for rate feed freshness
+  - source: SortedOracles.isOldestReportExpired(address rateFeed)(bool,address)
+    schedule: 0/10 * * * * *
+    type: gauge
+    chains: all
+    variants:
+${relayers.map(({ rateFeed }) => `      - [relayed:${rateFeed}]`).join("\n")}
+
+  # Checks if the signer wallets have enough CELO to pay for the relay() transactions
+  - source: CELOToken.balanceOf(address owner)(uint256)
+    schedule: 0/10 * * * * *
+    type: gauge
+    chains: all
+    variants:
+${relayers.map(({ rateFeed }) => `      - [RelayerSigner${rateFeed}]`).join("\n")}
+
+################################################################
+# Copy/paste the relevant values above into aegis' config.yaml #
+################################################################
+`;
+}
+
+void aegisExport();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { getAddress, keccak256, toHex } from "viem";
 import { HDAccount, mnemonicToAccount } from "viem/accounts";
 
 import { createHash } from "crypto";
@@ -23,4 +24,28 @@ export function deriveRelayerAccount(
   const accountIndex = parseInt(hash, 16) % 2 ** 31;
 
   return mnemonicToAccount(mnemonic, { accountIndex });
+}
+
+/**
+ * A JavaScript implementation of our rateFeed ID generation algorithm.
+ * Original solidity code is: address(uint160(uint256(keccak256(abi.encodePacked(rateFeed)))))
+}
+ * @param rateFeed The rate feed name in string format, i.e. "PHPUSD" or "CELOPHP"
+ * @returns The rate feed ID in address format, i.e. "0xab921d6ab1057601A9ae19879b111fC381a2a8E9" for PHPUSD
+ */
+export function toRateFeedId(rateFeed: string) {
+  // 1. Calculate keccak256 hash
+  const hashedBytes = keccak256(toHex(rateFeed));
+
+  // 2. Convert to BigInt (equivalent to uint256)
+  const hashAsBigInt = BigInt(hashedBytes);
+
+  // 3. Mask to 160 bits (equivalent to uint160)
+  const maskedToUint160 = hashAsBigInt & ((1n << 160n) - 1n);
+
+  // 4. Convert to address (hex string)
+  const addressHex = "0x" + maskedToUint160.toString(16).padStart(40, "0");
+
+  // 5. Return calculated rate feed ID
+  return getAddress(addressHex);
 }


### PR DESCRIPTION
### Description
To make it easier to add newly deployed relayed rate feeds to aegis for monitoring purposes, this PR adds a `npm run aegis:export` script that will print out the necessary aegis `config.yaml` values so we can easily copy/paste them over to aegis.

### Why does this need to be in this repo?
Because we derive all signer wallet addresses from a mnemonic which is managed by the oracle relayer project. And that derivation logic also lives here. And deploying new relayers also happens here. So it felt kinda natural to at least offer the aegis example as a logical next step, because after deploying you likely want to set up monitoring.

### How to test
- [ ] Check out this branch locally
- [ ] Run `npm run aegis:export`
- [ ] See that it prints out aegis-compatible YAML code
- [ ] Copy/paste the relevant YAML sections into aegis into config.local.yaml and run `npm run dev` to see that the generated YAML is valid and actually works