### PR TITLE
Enable cloud tracing

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -20,4 +20,6 @@ commitlint.config.mjs
 eslint.config.mjs
 infra
 
+src/aegis-export.ts
+
 #!include:.gitignore

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ For most local `terraform` or `gcloud` problems, your first steps should always 
   - `dev`: Starts a local server for the cloud function code (with hot-reloading via `nodemon`)
   - `start`: Starts a local server for the cloud function code (without hot-reloading)
   - `test`: Triggers a local cloud function server with a mocked PubSub event
+- **Switching Between Environments**
+  - `staging`: Switches the terraform workspace and your local `gcloud` project to staging
+  - `prod`: Switches the terraform workspace and your local `gcloud` project to prod
 - **Deploying and Destroying**
   - `deploy:function:staging`: Deploys the cloud function to staging (via `gcloud functions deploy`)
   - `deploy:function:prod`: Deploys the cloud function to production (via `gcloud functions deploy`)

--- a/bin/get-function-logs-url.sh
+++ b/bin/get-function-logs-url.sh
@@ -9,6 +9,12 @@ get_function_logs_url() {
 	script_dir=$(dirname "$0")
 	source "${script_dir}/select-environment.sh" "$1"
 
+	# Get time 1 hour ago in UTC
+	start_time=$(date -u -v-1H +"%Y-%m-%dT%H:%M:%S.000Z")
+
+	# Get current time in UTC
+	end_time=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+
 	logs_explorer_url=$(
 		cat <<EOF | tr -d '\n' | sed 's/[[:space:]]//g'
 https://console.cloud.google.com/logs/query;
@@ -22,6 +28,8 @@ query=%2528
 	severity%3E%3DDEFAULT;
 storageScope=project;
 summaryFields=labels%252FrateFeed,labels%252Fnetwork:false:32:beginning;
+startTime=${start_time};
+endTime=${end_time};
 ?project=${project_id}
 EOF
 	)

--- a/bin/get-function-logs-url.sh
+++ b/bin/get-function-logs-url.sh
@@ -9,8 +9,28 @@ get_function_logs_url() {
 	script_dir=$(dirname "$0")
 	source "${script_dir}/select-environment.sh" "$1"
 
+	logs_explorer_url=$(
+		cat <<EOF | tr -d '\n' | sed 's/[[:space:]]//g'
+https://console.cloud.google.com/logs/query;
+query=%2528
+	resource.type%20%3D%20%22cloud_function%22%0A
+	resource.labels.function_name%20%3D%20%22${function_name}%22%0A
+	resource.labels.region%20%3D%20%22${region}%22%2529%0A%20OR%20%0A%2528
+	resource.type%20%3D%20%22cloud_run_revision%22%0A
+	resource.labels.service_name%20%3D%20%22${function_name}%22%0A
+	resource.labels.location%20%3D%20%22${region}%22%2529%0A%20
+	severity%3E%3DDEFAULT;
+storageScope=project;
+summaryFields=labels%252FrateFeed,labels%252Fnetwork:false:32:beginning;
+?project=${project_id}
+EOF
+	)
+
+	printf '\n\033[1mLogs Explorer URL\033[0m - Your function logs in the GCP Logs Explorer, usually this is what you want.\n%s\n' "${logs_explorer_url}"
+
 	function_logs_url="https://console.cloud.google.com/functions/details/${region}/${function_name}?project=${project_id}&tab=logs "
-	printf '\n\033[1mCloud Function Logs\033[0m - The runtime logs of your function, usually this is what you want.\n%s\n' "${function_logs_url}"
+	printf '\n\033[1mCloud Function Logs\033[0m - A simplified logs view..\n%s\n' "${function_logs_url}"
+
 	echo ""
 
 	cloud_run_logs_url="https://console.cloud.google.com/run/detail/${region}/${function_name}/logs?${project_id}"

--- a/infra/cloud_function.tf
+++ b/infra/cloud_function.tf
@@ -79,7 +79,7 @@ resource "google_storage_bucket" "relay_function" {
 
 # Upload the Cloud Function source code to the Storage Bucket
 resource "google_storage_bucket_object" "source_code" {
-  name   = "function-source-${terraform.workspace}-${data.archive_file.function_source.output_sha256}.zip"
+  name   = "function-source-${terraform.workspace}-${data.archive_file.function_source.output_md5}.zip"
   bucket = google_storage_bucket.relay_function.name
   source = data.archive_file.function_source.output_path
 }

--- a/infra/cloud_function.tf
+++ b/infra/cloud_function.tf
@@ -57,7 +57,7 @@ data "archive_file" "function_source" {
   output_path = "${path.module}/../function-source.zip"
 
   # Not sure if this is stricly necessary when defining a .gcloudignore file, but better safe than sorry
-  excludes = [".env", ".env.example", ".env.yaml", ".git", ".gitignore", ".trunk", ".vscode", "README.md", "dist", "commitlint.config.mjs", "eslint.config.mjs", "infra", "node_modules"]
+  excludes = [".env", ".env.example", ".env.yaml", ".git", ".gitignore", ".trunk", ".vscode", "README.md", "dist", "commitlint.config.mjs", "eslint.config.mjs", "infra", "node_modules", "src/aegis-export.ts"]
 }
 
 # Storage Bucket for the Cloud Function source code

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "logs:url": "npm run logs:function:url:staging",
     "plan:prod": "terraform -chdir=infra workspace select prod && terraform -chdir=infra plan",
     "plan:staging": "terraform -chdir=infra workspace select staging && terraform -chdir=infra plan",
+    "prod": "terraform -chdir=infra workspace select prod && npm run cache:clear",
+    "staging": "terraform -chdir=infra workspace select staging && npm run cache:clear",
     "prestart": "npm run build",
     "start": "NODE_ENV=development functions-framework --target=relay",
     "test": "npm run test:local",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ cloudEvent("relay", async (event: CloudEvent<PubsubData>) => {
     };
   }
 
-  const logger = getLogger(rateFeedName, network);
+  const logger = getLogger(rateFeedName, network, event.id);
   const ok = await relay(relayerAddress, rateFeedName, logger);
   if (!ok) {
     return { status: "error", message: "Relay failed" };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { cloudEvent, CloudEvent } from "@google-cloud/functions-framework";
 import config from "./config";
+import getLogger from "./logger";
 import relay from "./relay";
 import type { PubsubData, RelayRequested } from "./types";
 
@@ -18,7 +19,9 @@ cloudEvent("relay", async (event: CloudEvent<PubsubData>) => {
     return { status: "error", message: "Invalid event data format" };
   }
 
-  let parsedEventData, rateFeedName, relayerAddress;
+  let parsedEventData: RelayRequested,
+    rateFeedName: string,
+    relayerAddress: string;
   try {
     const decodedEventData = Buffer.from(eventData, "base64").toString("utf-8");
     parsedEventData = JSON.parse(decodedEventData) as RelayRequested;
@@ -36,7 +39,8 @@ cloudEvent("relay", async (event: CloudEvent<PubsubData>) => {
     };
   }
 
-  const ok = await relay(relayerAddress, rateFeedName, network);
+  const logger = getLogger(rateFeedName, network);
+  const ok = await relay(relayerAddress, rateFeedName, logger);
   if (!ok) {
     return { status: "error", message: "Relay failed" };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import config from "./config";
 import getLogger from "./logger";
 import relay from "./relay";
 import type { PubsubData, RelayRequested } from "./types";
+import { getTraceId } from "./utils";
 
 const isMainnet = config.NODE_ENV !== "development";
 const network = isMainnet ? "Celo" : "Alfajores";
@@ -39,8 +40,10 @@ cloudEvent("relay", async (event: CloudEvent<PubsubData>) => {
     };
   }
 
-  const logger = getLogger(rateFeedName, network, event.id);
+  const traceId = getTraceId(event);
+  const logger = getLogger(rateFeedName, network, traceId);
   const ok = await relay(relayerAddress, rateFeedName, logger);
+
   if (!ok) {
     return { status: "error", message: "Relay failed" };
   }

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -9,10 +9,10 @@ import {
 } from "viem";
 import { celo, celoAlfajores } from "viem/chains";
 
+import type { Logger } from "winston";
 import config from "./config";
 import sendDiscordNotification from "./send-discord-notification";
 import getSecret from "./get-secret";
-import getLogger from "./logger";
 import { relayerAbi } from "./relayer-abi";
 import { deriveRelayerAccount } from "./utils";
 
@@ -29,9 +29,8 @@ const contractCodeCache = new Map<string, boolean>();
 export default async function relay(
   relayerAddress: string,
   rateFeedName: string,
-  network: string,
+  logger: Logger,
 ): Promise<boolean> {
-  const logger = getLogger(rateFeedName, network);
   logger.info(`Relay request received for ${relayerAddress}`);
 
   if (!(await isContract(relayerAddress))) {
@@ -160,7 +159,7 @@ async function isContract(address: string): Promise<boolean> {
 async function handleContractFunctionRevertError(
   rateFeedName: string,
   revertError: ContractFunctionRevertedError,
-  logger: ReturnType<typeof getLogger>,
+  logger: Logger,
 ) {
   const errName = revertError.data?.errorName ?? "";
   switch (errName) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
 export interface PubsubData {
-  subscription: string;
   message: {
+    attributes?: Record<string, string>;
+    data: string;
     messageId: string;
     publishTime: string;
-    data: string;
-    attributes?: Record<string, string>;
   };
+  subscription: string;
 }
 
 export interface RelayRequested {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { getAddress, keccak256, toHex } from "viem";
+import { Address, getAddress, keccak256, toHex } from "viem";
 import { HDAccount, mnemonicToAccount } from "viem/accounts";
 
 import { createHash } from "crypto";
@@ -33,7 +33,7 @@ export function deriveRelayerAccount(
  * @param rateFeed The rate feed name in string format, i.e. "PHPUSD" or "CELOPHP"
  * @returns The rate feed ID in address format, i.e. "0xab921d6ab1057601A9ae19879b111fC381a2a8E9" for PHPUSD
  */
-export function toRateFeedId(rateFeed: string) {
+export function toRateFeedId(rateFeed: string): Address {
   // 1. Calculate keccak256 hash
   const hashedBytes = keccak256(toHex(rateFeed));
 


### PR DESCRIPTION
### Description
This simplifies grouping function logs by trace id (think: a specific function execution).

Concretely returns locks from this:

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/99834ad7-53b0-4f25-9859-9a7b8af0e350">

to this:

<img width="1118" alt="Pasted_Image_18_09_24__16_13" src="https://github.com/user-attachments/assets/be6ec60e-13d3-4748-ba82-f5b49f1e92ef">


Clicking that new little blue icon should allow you to filter only logs belonging to that function execution:

<img width="242" alt="image" src="https://github.com/user-attachments/assets/832f0b60-f7a5-4fb7-a972-c6414d64cd4c">

And you should end up seeing only the logs belonging to this particular function execution:

<img width="1116" alt="Screenshot 2024-09-18 at 16 38 52" src="https://github.com/user-attachments/assets/16d20bdc-97d9-4237-b9d1-822466570a35">

### How to test
- [x] Check out this branch locally
- [x] Make sure your local `gcloud` cli is pointed to the oracle relayer staging project via `npm run staging`
- [x] Run `npm run logs:url`
- [x] Click on the Logs Explorer URL printed out in your CLI (the first and longest of the three)
- [x] Click a few of the blue trace filter icons shown above to confirm it works