### PR TITLE
feat: add --dry-run flag to refill-relayers

### DIFF
--- a/src/refill-relayers.ts
+++ b/src/refill-relayers.ts
@@ -46,14 +46,17 @@ async function main() {
   const chainArg = process.argv[2];
   if (!chainArg || !(chainArg in chains)) {
     console.log(
-      "Usage: pnpm refill:celo | pnpm refill:celo-sepolia | pnpm refill:monad | pnpm refill:monad-testnet | pnpm refill:polygon-testnet",
+      "Usage: pnpm refill:celo | pnpm refill:celo-sepolia | pnpm refill:monad | pnpm refill:monad-testnet | pnpm refill:polygon-testnet [--dry-run]",
     );
     process.exit(1);
   }
 
+  const dryRun = process.argv.includes("--dry-run");
   const chain = chains[chainArg];
   const symbol = chain.nativeCurrency.symbol;
-  console.log(`Refilling relayer accounts on ${chainArg}...`);
+  console.log(
+    `Refilling relayer accounts on ${chainArg}${dryRun ? " (dry run)" : ""}...`,
+  );
 
   const relayerAddressesPath = path.resolve(
     process.cwd(),
@@ -100,8 +103,18 @@ async function main() {
 
     if (balanceInNative < MIN_BALANCE_THRESHOLD) {
       console.log(
-        `  Low balance detected. Transferring ${TRANSFER_AMOUNT.toString()} ${symbol}...`,
+        `  Low balance detected. ${dryRun ? "Would transfer" : "Transferring"} ${TRANSFER_AMOUNT.toString()} ${symbol}...`,
       );
+
+      if (dryRun) {
+        transfersMade.push({
+          rateFeed: rateFeedKey,
+          address: relayerAccount.address,
+          amount: TRANSFER_AMOUNT,
+          hash: "(dry run — not submitted)",
+        });
+        continue;
+      }
 
       try {
         const hash = await walletClient.sendTransaction({
@@ -110,7 +123,6 @@ async function main() {
           chain,
         });
         await publicClient.waitForTransactionReceipt({ hash });
-        // let hash = "0x1234567890";
 
         console.log(`  Transaction sent: ${hash}`);
         transfersMade.push({


### PR DESCRIPTION
## Summary
- Add `--dry-run` flag to the `refill-relayers` script so refill decisions can be previewed without submitting transactions.
- Low-balance accounts are still detected and reported, but no transaction is sent and the summary lists them with a `(dry run — not submitted)` placeholder hash.
- Drop a stale commented-out debug line.

## Test plan
- [ ] `pnpm refill:celo-sepolia --dry-run` reports would-be transfers without submitting any tx
- [ ] `pnpm refill:celo-sepolia` (no flag) still submits transactions as before
- [ ] Usage message lists `[--dry-run]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to a CLI script and only gates whether transactions are submitted, with clear logging and unchanged default behavior when the flag is omitted.
> 
> **Overview**
> Adds a `--dry-run` flag to `src/refill-relayers.ts` so low-balance relayer refills can be *previewed* without broadcasting transactions.
> 
> When enabled, the script logs "would transfer" messages and records placeholder transfer entries (`(dry run — not submitted)`) in the final summary; otherwise it continues to submit and wait for real transactions as before, and updates the usage/help output accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901146d8adc26ce43423f4965fdead6188b91deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->