### PR TITLE
fix: dedicated Celo RPC + nonce-too-low retry to stop stale-relay alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Each environment hosts multiple cloud functions (one per chain), sharing the sam
    # Get it from our VictorOps by going to `Integrations` > `Stackdriver` and copying the URL. The routing key can be found under the settings tab
    victorops_webhook_url   = "<victorops-webhook-url>/<victorops-routing-key>"
 
+   # Optional (mainnet only): dedicated Celo RPC URL (e.g. a QuickNode HTTPS endpoint).
+   # When set, the relayer uses it as the primary RPC and falls back to the public
+   # Forno RPC. Leave unset to use only the public RPC. Stored in Secret Manager.
+   # celo_rpc_url = "<quicknode-celo-mainnet-https-url>"
+
    ```
 
 1. Verify that everything works

--- a/infra/cloud-function.tf
+++ b/infra/cloud-function.tf
@@ -24,15 +24,19 @@ resource "google_cloudfunctions2_function" "relay" {
     service_account_email = module.oracle_relayer.service_account_email
     timeout_seconds       = 60
 
-    environment_variables = {
-      GCP_PROJECT_ID                = module.oracle_relayer.project_id
-      DISCORD_WEBHOOK_URL_SECRET_ID = google_secret_manager_secret.discord_webhook_url.secret_id
-      RELAYER_MNEMONIC_SECRET_ID    = google_secret_manager_secret.relayer_mnemonic.secret_id
-      # Logs execution ID for easier debugging => https://cloud.google.com/functions/docs/monitoring/logging#viewing_runtime_logs
-      LOG_EXECUTION_ID = "true"
-      NODE_ENV         = each.value.is_production ? "production" : "development"
-      CHAIN            = each.key
-    }
+    environment_variables = merge(
+      {
+        GCP_PROJECT_ID                = module.oracle_relayer.project_id
+        DISCORD_WEBHOOK_URL_SECRET_ID = google_secret_manager_secret.discord_webhook_url.secret_id
+        RELAYER_MNEMONIC_SECRET_ID    = google_secret_manager_secret.relayer_mnemonic.secret_id
+        # Logs execution ID for easier debugging => https://cloud.google.com/functions/docs/monitoring/logging#viewing_runtime_logs
+        LOG_EXECUTION_ID = "true"
+        NODE_ENV         = each.value.is_production ? "production" : "development"
+        CHAIN            = each.key
+      },
+      # Only set when a dedicated RPC URL is configured for this chain (see secret-manager.tf)
+      each.value.rpc_url_secret_id != null ? { RPC_URL_SECRET_ID = each.value.rpc_url_secret_id } : {},
+    )
   }
 
   event_trigger {

--- a/infra/cloud-function.tf
+++ b/infra/cloud-function.tf
@@ -34,8 +34,10 @@ resource "google_cloudfunctions2_function" "relay" {
         NODE_ENV         = each.value.is_production ? "production" : "development"
         CHAIN            = each.key
       },
-      # Only set when a dedicated RPC URL is configured for this chain (see secret-manager.tf)
-      each.value.rpc_url_secret_id != null ? { RPC_URL_SECRET_ID = each.value.rpc_url_secret_id } : {},
+      # Only set when a dedicated RPC URL is configured for this chain. References
+      # the secret resource (not the raw var) so Terraform orders the function
+      # after the secret on first apply, like the discord/mnemonic env vars.
+      each.value.rpc_url_secret_id != null ? { RPC_URL_SECRET_ID = one(google_secret_manager_secret.celo_rpc_url[*].secret_id) } : {},
     )
   }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -10,12 +10,18 @@ locals {
 
   mock_aggregator_updater_chains = terraform.workspace == "testnet" ? ["celo-sepolia", "monad-testnet", "polygon-testnet"] : []
 
+  # Whether a dedicated RPC URL is configured. nonsensitive() is safe here: it
+  # exposes only whether the URL is empty (a presence flag), never the URL
+  # itself — and is required because count/for_each reject sensitive-derived
+  # values (chain_configs feeds for_each in cloud-function/scheduler/pubsub).
+  celo_rpc_url_enabled = nonsensitive(var.celo_rpc_url != "")
+
   chain_configs = {
     for chain in local.chains : chain => {
       relayer_addresses = local.relayer_addresses[chain]
       is_production     = terraform.workspace == "mainnet"
       # Only celo (mainnet) uses a dedicated RPC URL for now; null => default public RPC
-      rpc_url_secret_id = (chain == "celo" && var.celo_rpc_url != "") ? var.rpc_url_secret_id : null
+      rpc_url_secret_id = (chain == "celo" && local.celo_rpc_url_enabled) ? var.rpc_url_secret_id : null
     }
   }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -14,6 +14,8 @@ locals {
     for chain in local.chains : chain => {
       relayer_addresses = local.relayer_addresses[chain]
       is_production     = terraform.workspace == "mainnet"
+      # Only celo (mainnet) uses a dedicated RPC URL for now; null => default public RPC
+      rpc_url_secret_id = (chain == "celo" && var.celo_rpc_url != "") ? var.rpc_url_secret_id : null
     }
   }
 

--- a/infra/secret-manager.tf
+++ b/infra/secret-manager.tf
@@ -41,3 +41,24 @@ resource "google_secret_manager_secret_version" "discord_webhook_url" {
   secret      = google_secret_manager_secret.discord_webhook_url.id
   secret_data = local.discord_webhook_url
 }
+
+# Dedicated Celo mainnet RPC URL (e.g. a QuickNode HTTPS endpoint). Optional:
+# created only on the mainnet workspace when `celo_rpc_url` is set. The relayer
+# uses it as its primary RPC and falls back to the public Forno RPC, which is
+# load-balanced across lagging nodes (cause of "nonce too low" rejections).
+# Consumed by the celo cloud function via the RPC_URL_SECRET_ID env var.
+resource "google_secret_manager_secret" "celo_rpc_url" {
+  count     = terraform.workspace == "mainnet" && var.celo_rpc_url != "" ? 1 : 0
+  project   = module.oracle_relayer.project_id
+  secret_id = var.rpc_url_secret_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "celo_rpc_url" {
+  count       = terraform.workspace == "mainnet" && var.celo_rpc_url != "" ? 1 : 0
+  secret      = google_secret_manager_secret.celo_rpc_url[0].id
+  secret_data = var.celo_rpc_url
+}

--- a/infra/secret-manager.tf
+++ b/infra/secret-manager.tf
@@ -48,7 +48,7 @@ resource "google_secret_manager_secret_version" "discord_webhook_url" {
 # load-balanced across lagging nodes (cause of "nonce too low" rejections).
 # Consumed by the celo cloud function via the RPC_URL_SECRET_ID env var.
 resource "google_secret_manager_secret" "celo_rpc_url" {
-  count     = terraform.workspace == "mainnet" && var.celo_rpc_url != "" ? 1 : 0
+  count     = terraform.workspace == "mainnet" && local.celo_rpc_url_enabled ? 1 : 0
   project   = module.oracle_relayer.project_id
   secret_id = var.rpc_url_secret_id
 
@@ -58,7 +58,7 @@ resource "google_secret_manager_secret" "celo_rpc_url" {
 }
 
 resource "google_secret_manager_secret_version" "celo_rpc_url" {
-  count       = terraform.workspace == "mainnet" && var.celo_rpc_url != "" ? 1 : 0
+  count       = terraform.workspace == "mainnet" && local.celo_rpc_url_enabled ? 1 : 0
   secret      = google_secret_manager_secret.celo_rpc_url[0].id
   secret_data = var.celo_rpc_url
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -40,6 +40,21 @@ variable "mock_aggregator_reporter_private_key" {
   default   = ""
 }
 
+# Optional dedicated RPC URL for Celo mainnet (e.g. a QuickNode HTTPS endpoint).
+# When set, the relayer uses it as the primary RPC and falls back to the chain's
+# default public RPC (Forno). Leave empty to use only the default public RPC.
+# The default public RPCs are load-balanced across nodes at differing chain
+# heights, whose lagging reads cause "nonce too low" rejections.
+variable "celo_rpc_url" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+variable "rpc_url_secret_id" {
+  type    = string
+  default = "celo-rpc-url"
+}
 # Webhook URL to send monitoring alerts from within GCP Monitoring
 # You can find this URL in Victorops by going to "Integrations" -> "Stackdriver".
 # The routing key can be found under "Settings" -> "Routing Keys"

--- a/package-lock.json
+++ b/package-lock.json
@@ -515,18 +515,6 @@
         "winston": ">=3.2.1"
       }
     },
-    "node_modules/@google-cloud/logging/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
@@ -2991,18 +2979,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/gcp-metadata": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
@@ -3163,18 +3139,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/google-gax/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gopd": {
@@ -5076,18 +5040,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -5288,10 +5240,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "overrides": {
     "form-data": "2.5.5",
     "@tootallnate/once": "3.0.1",
-    "tar": "7.5.15"
+    "tar": "7.5.15",
+    "uuid": "11.1.1"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,10 @@ export interface Env {
   GCP_PROJECT_ID: string;
   NODE_ENV: string;
   RELAYER_MNEMONIC_SECRET_ID: string;
+  // Optional Secret Manager secret ID holding the primary RPC URL (e.g. a
+  // dedicated QuickNode endpoint). When unset, the chain's default public RPC
+  // is used. See getOrCreate*Client in relay.ts.
+  RPC_URL_SECRET_ID?: string;
   CHAIN:
     | "celo"
     | "celo-sepolia"
@@ -27,6 +31,7 @@ const schema: JSONSchemaType<Env> = {
     GCP_PROJECT_ID: { type: "string" },
     NODE_ENV: { type: "string" },
     RELAYER_MNEMONIC_SECRET_ID: { type: "string" },
+    RPC_URL_SECRET_ID: { type: "string", nullable: true },
     CHAIN: {
       type: "string",
       enum: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export interface Env {
   RELAYER_MNEMONIC_SECRET_ID: string;
   // Optional Secret Manager secret ID holding the primary RPC URL (e.g. a
   // dedicated QuickNode endpoint). When unset, the chain's default public RPC
-  // is used. See getOrCreate*Client in relay.ts.
+  // is used. See initTransport() in relay.ts.
   RPC_URL_SECRET_ID?: string;
   CHAIN:
     | "celo"

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -164,32 +164,36 @@ export default async function relay(
 ): Promise<boolean> {
   logger.info(`Relay request received for ${relayerAddress}`);
 
-  await initTransport();
-
-  if (!(await isContract(relayerAddress))) {
-    logger.error(
-      `Relay failed. Relayer address ${relayerAddress} is not a contract.`,
-    );
-    return false;
-  }
-
-  const publicClient = getOrCreatePublicClient();
-  const wallet = await getOrCreateWalletClient(rateFeedName);
-
-  const contract: RelayerContract = getContract({
-    address: relayerAddress as Address,
-    abi: relayerAbi,
-    client: { public: publicClient, wallet },
-  });
+  // Declared outside the try so the catch can use whatever was already
+  // initialized. The try covers every RPC-touching step (not just submitTx):
+  // a viem error thrown e.g. by isContract's getCode would otherwise escape to
+  // the Functions runtime unredacted and leak the dedicated RPC URL into logs.
+  let client: PublicClient | undefined;
+  let contract: RelayerContract | undefined;
+  let signerAddress = "<undefined>";
 
   try {
-    return await submitTx(
-      contract,
-      publicClient,
-      wallet,
-      isRetryAttempt,
-      logger,
-    );
+    await initTransport();
+
+    if (!(await isContract(relayerAddress))) {
+      logger.error(
+        `Relay failed. Relayer address ${relayerAddress} is not a contract.`,
+      );
+      return false;
+    }
+
+    client = getOrCreatePublicClient();
+    const wallet = await getOrCreateWalletClient(rateFeedName);
+    signerAddress =
+      (wallet.account?.address as string | undefined) ?? "<undefined>";
+
+    contract = getContract({
+      address: relayerAddress as Address,
+      abi: relayerAbi,
+      client: { public: client, wallet },
+    });
+
+    return await submitTx(contract, client, wallet, isRetryAttempt, logger);
   } catch (err) {
     if (!(err instanceof BaseError)) {
       // Theoretically should never happen, as all errors in Viem should extend BaseError
@@ -204,10 +208,17 @@ export default async function relay(
     const revertError = err.walk(
       (err) => err instanceof ContractFunctionRevertedError,
     );
-    if (revertError instanceof ContractFunctionRevertedError) {
+    // A revert can only originate from simulate/write on the contract, so
+    // contract/client are always initialized on this path — the guard just
+    // satisfies the type system.
+    if (
+      revertError instanceof ContractFunctionRevertedError &&
+      contract &&
+      client
+    ) {
       await handleContractFunctionRevertError(
         contract,
-        publicClient,
+        client,
         rateFeedName,
         revertError,
         logger,
@@ -218,8 +229,6 @@ export default async function relay(
     // At this point we know that the error is not a revert from the contract, so it could be an error
     // from the rpc client, i.e. not enough balance, incorrect nonce, tx broadcast timeout, etc,. in
     // which case the shortMessage should be descriptive enough
-    const signerAddress =
-      (wallet.account?.address as string | undefined) ?? "<undefined>";
     return await handleNonRevertError(
       relayerAddress,
       rateFeedName,

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -59,6 +59,7 @@ const contractCodeCache = new Map<string, boolean>();
 // differing chain heights, whose lagging reads cause "nonce too low" rejections
 // and stale receipt/price reads.
 let cachedTransport: Transport | undefined;
+let dedicatedRpcUrl: string | undefined;
 
 async function initTransport(): Promise<void> {
   if (cachedTransport) {
@@ -76,10 +77,23 @@ async function initTransport(): Promise<void> {
         `RPC URL secret '${config.RPC_URL_SECRET_ID}' resolved to an empty value`,
       );
     }
+    dedicatedRpcUrl = rpcUrl;
     cachedTransport = fallback([http(rpcUrl), http()]);
   } else {
     cachedTransport = http();
   }
+}
+
+/**
+ * The dedicated RPC URL embeds an access token, and viem request errors carry
+ * the full request URL (as `url` and in `metaMessages`), so anything that
+ * serializes a viem error must pass through here to keep the token out of
+ * Cloud Logging.
+ */
+function redactRpcUrl(text: string): string {
+  return dedicatedRpcUrl
+    ? text.replaceAll(dedicatedRpcUrl, "<dedicated-rpc-url>")
+    : text;
 }
 
 function getTransport(): Transport {
@@ -348,7 +362,7 @@ async function handleContractFunctionRevertError(
     }
     case "InvalidPrice": {
       logger.error("Relay failed. Chainlink price is invalid");
-      logger.error(JSON.stringify(revertError, null, 2));
+      logger.error(redactRpcUrl(JSON.stringify(revertError, null, 2)));
       await sendInvalidPriceNotification(rateFeedName);
       break;
     }
@@ -516,7 +530,16 @@ async function handleNonRevertError(
   const isStaleNonce =
     nonceError instanceof NonceTooLowError &&
     /nonce too low/i.test(`${nonceError.details} ${err.details}`);
-  if (!isRetryAttempt && isStaleNonce) {
+  if (isStaleNonce) {
+    if (isRetryAttempt) {
+      // Don't fall through to the generic "unknown non-revert error" branch —
+      // we know exactly what happened, and operators grep for this case.
+      logger.error(
+        `Relay failed. Nonce was still stale after retrying with a fresh nonce for signer ${signerAddress}. Will not retry again.`,
+      );
+      return false;
+    }
+
     logger.info(
       `Relay failed with a stale nonce for signer ${signerAddress}, will retry once with a fresh nonce`,
     );
@@ -550,7 +573,7 @@ async function handleNonRevertError(
       logger.error(
         `Relay failed with an unknown non-revert error: ${err.shortMessage}`,
       );
-      logger.error(JSON.stringify(err, null, 2));
+      logger.error(redactRpcUrl(JSON.stringify(err, null, 2)));
       return false;
   }
 }

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -64,14 +64,22 @@ async function initTransport(): Promise<void> {
   if (cachedTransport) {
     return;
   }
-  // Only cache on success: if the secret load throws, leave cachedTransport
-  // unset so the next invocation retries instead of pinning this warm instance
-  // to the default RPC. Treated as a hard dependency like the mnemonic secret —
-  // both fail the relay (and retry next minute) if Secret Manager is unreachable.
-  const rpcUrl = config.RPC_URL_SECRET_ID
-    ? (await getSecret(config.RPC_URL_SECRET_ID)).trim()
-    : undefined;
-  cachedTransport = rpcUrl ? fallback([http(rpcUrl), http()]) : http();
+  // Only cache on success: if the secret is missing/empty or the load throws,
+  // leave cachedTransport unset so the next invocation retries instead of
+  // pinning this warm instance to the default RPC. Treated as a hard dependency
+  // like the mnemonic secret — both fail the relay (and retry next minute) if
+  // Secret Manager is unreachable or misconfigured.
+  if (config.RPC_URL_SECRET_ID) {
+    const rpcUrl = (await getSecret(config.RPC_URL_SECRET_ID)).trim();
+    if (!rpcUrl) {
+      throw new Error(
+        `RPC URL secret '${config.RPC_URL_SECRET_ID}' resolved to an empty value`,
+      );
+    }
+    cachedTransport = fallback([http(rpcUrl), http()]);
+  } else {
+    cachedTransport = http();
+  }
 }
 
 function getTransport(): Transport {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -3,6 +3,7 @@ import type {
   Chain,
   GetContractReturnType,
   PublicClient,
+  Transport,
   WalletClient,
 } from "viem";
 import {
@@ -11,8 +12,10 @@ import {
   createPublicClient,
   createWalletClient,
   encodeFunctionData,
+  fallback,
   getContract,
   http,
+  NonceTooLowError,
 } from "viem";
 import {
   celo,
@@ -48,6 +51,34 @@ const walletClients: Map<string, WalletClient> = new Map<
   WalletClient
 >();
 const contractCodeCache = new Map<string, boolean>();
+
+// Shared transport, initialized once per instance via initTransport(). When an
+// RPC URL secret is configured we prefer it (a dedicated endpoint with
+// consistent state) and fall back to the chain's default public RPC. The
+// default public RPCs (e.g. Celo's Forno) are load-balanced across nodes at
+// differing chain heights, whose lagging reads cause "nonce too low" rejections
+// and stale receipt/price reads.
+let cachedTransport: Transport | undefined;
+
+async function initTransport(): Promise<void> {
+  if (cachedTransport) {
+    return;
+  }
+  // Only cache on success: if the secret load throws, leave cachedTransport
+  // unset so the next invocation retries instead of pinning this warm instance
+  // to the default RPC. Treated as a hard dependency like the mnemonic secret —
+  // both fail the relay (and retry next minute) if Secret Manager is unreachable.
+  const rpcUrl = config.RPC_URL_SECRET_ID
+    ? (await getSecret(config.RPC_URL_SECRET_ID)).trim()
+    : undefined;
+  cachedTransport = rpcUrl ? fallback([http(rpcUrl), http()]) : http();
+}
+
+function getTransport(): Transport {
+  // initTransport() runs at the top of relay() before any client is created
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return cachedTransport!;
+}
 
 type RelayerContract = GetContractReturnType<typeof relayerAbi, PublicClient>;
 
@@ -110,6 +141,8 @@ export default async function relay(
   isRetryAttempt = false,
 ): Promise<boolean> {
   logger.info(`Relay request received for ${relayerAddress}`);
+
+  await initTransport();
 
   if (!(await isContract(relayerAddress))) {
     logger.error(
@@ -181,7 +214,7 @@ function getOrCreatePublicClient(): PublicClient {
   if (!publicClient) {
     publicClient = createPublicClient({
       chain: chainMap[config.CHAIN],
-      transport: http(),
+      transport: getTransport(),
       // NOTE: viem's typescript support is super annoying, couldn't figure out how to make this work without the cast
     }) as unknown as PublicClient;
   }
@@ -199,7 +232,7 @@ async function getOrCreateWalletClient(
     const newWalletClient = createWalletClient({
       account: deriveRelayerAccount(mnemonic, rateFeedName),
       chain: chainMap[config.CHAIN],
-      transport: http(),
+      transport: getTransport(),
     });
     walletClients.set(rateFeedName, newWalletClient);
   }
@@ -463,6 +496,25 @@ async function handleNonRevertError(
   err: BaseError,
   logger: Logger,
 ): Promise<boolean> {
+  // A stale nonce read — e.g. from a lagging public RPC node that hasn't yet
+  // seen our previous tx — makes the sequencer reject the tx as "nonce too low".
+  // The tx never broadcasts, so it's safe to re-fetch the nonce and submit once
+  // more (the retry re-reads getTransactionCount from the configured RPC).
+  // viem's NonceTooLowError also covers "already known" / "transaction already
+  // imported", which instead mean the tx is already in the mempool — retrying
+  // those with a fresh nonce would broadcast a duplicate relay, so match the
+  // strict "nonce too low" message rather than the error class alone.
+  const nonceError = err.walk((e) => e instanceof NonceTooLowError);
+  const isStaleNonce =
+    nonceError instanceof NonceTooLowError &&
+    /nonce too low/i.test(`${nonceError.details} ${err.details}`);
+  if (!isRetryAttempt && isStaleNonce) {
+    logger.info(
+      `Relay failed with a stale nonce for signer ${signerAddress}, will retry once with a fresh nonce`,
+    );
+    return await relay(relayerAddress, rateFeedName, logger, true);
+  }
+
   switch (err.details) {
     case "insufficient funds for transfer":
       logger.error(

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -193,7 +193,11 @@ export default async function relay(
   } catch (err) {
     if (!(err instanceof BaseError)) {
       // Theoretically should never happen, as all errors in Viem should extend BaseError
-      logger.error("Relay failed due to an unknown non-BaseError:", err);
+      logger.error(
+        redactRpcUrl(
+          `Relay failed due to an unknown non-BaseError: ${String(err)}`,
+        ),
+      );
       return false;
     }
 
@@ -372,7 +376,9 @@ async function handleContractFunctionRevertError(
     }
     default: {
       logger.error(
-        `Relay failed. Unknown error type: ${errName} - ${revertError.shortMessage}`,
+        redactRpcUrl(
+          `Relay failed. Unknown error type: ${errName} - ${revertError.shortMessage}`,
+        ),
       );
       break;
     }
@@ -571,7 +577,9 @@ async function handleNonRevertError(
       return await relay(relayerAddress, rateFeedName, logger, true);
     default:
       logger.error(
-        `Relay failed with an unknown non-revert error: ${err.shortMessage}`,
+        redactRpcUrl(
+          `Relay failed with an unknown non-revert error: ${err.shortMessage}`,
+        ),
       );
       logger.error(redactRpcUrl(JSON.stringify(err, null, 2)));
       return false;


### PR DESCRIPTION
## The Problem

Frequent **"Oracle Update Delayed"** alerts on celo rate feeds (CHF/EUR/JPY/USDC, etc.). Investigation showed the cause is **our relayer infra, not Chainlink**:

- **Chainlink is fine.** On-chain sweeps of the underlying aggregators (130 consecutive rounds each, ~9.3h) show updates every ~250–340s — **max gap 340s, never past the 360s SortedOracles expiry** on any feed.
- **We fail to land relays.** ~50–75% of actionable relays failed, dominated by `error_forwarding_sequencer: nonce too low` — **all off-by-exactly-one** (`next nonce N, tx nonce N-1`) — plus receipt timeouts. That's the fingerprint of stale reads from the **load-balanced public RPC (Forno)**: viem fetches `getTransactionCount(pending)` from a node that hasn't yet caught up to our previous tx, so it reuses an already-consumed nonce and the sequencer rejects it. The same lag also produced stale price reads.

## The Solution

- **Dedicated RPC with fallback.** Build a shared viem transport once per instance. When `RPC_URL_SECRET_ID` is set, use the dedicated RPC (QuickNode) as primary with the chain default as fallback: `fallback([http(rpcUrl), http()])`. Consistent state ⇒ correct nonce/receipt/price reads; Forno still auto-covers transient RPC outages.
- **Nonce-too-low retry.** Retry once on a genuine `nonce too low` rejection, re-reading the nonce. Matched on the strict message (not viem's `NonceTooLowError` class, which also covers `already known`/`already imported` — those mean the tx is already in the mempool, where a fresh-nonce resubmit would duplicate the relay).

## Details

- `src/config.ts` — optional `RPC_URL_SECRET_ID`.
- `infra/` — optional `celo_rpc_url` → Secret Manager secret → `RPC_URL_SECRET_ID` env var on the **celo (mainnet) function only**. The secret is a hard dependency when configured (like the mnemonic): the transport is only cached on a successful secret load, so a transient failure retries next invocation rather than pinning the warm instance to the public RPC.
- **Deploy:** mainnet rollout is via `npm run deploy:mainnet` (terraform creates the secret + sets the env var + ships the code). The code-only `deploy:function:celo` path leaves `RPC_URL_SECRET_ID` unset → falls back to the public RPC (current behaviour), so it stays safe.

### Known / deferred (non-blocking)
- The nonce retry reuses the existing `isRetryAttempt` flag, so it inherits the 2× gas bump meant for the stuck-mempool replacement path. Harmless (Celo gas is cheap, bounded to one retry); splitting the flags is a follow-up if desired.
- No unit tests added (repo has no unit-test harness; `test` is an integration script). Nonce-classification logic is a good candidate for future coverage.
- Unrelated drift spotted: `relayer_addresses.json`'s celo block omits the deployed `usdc_usd` relayer (`0xEF5d3917…`) — separate follow-up.

## Validation

- `tsc --noEmit`, `eslint`, `npm run build` — clean
- `terraform validate` + `terraform fmt` — clean
- `trunk fmt` + `trunk check` (8 files incl. `secret-manager.tf`) — no issues
- On-chain Chainlink cadence read directly from aggregators (zero gaps > 360s); nonce-error off-by-one pattern confirmed in 126 prod errors; viem `NonceTooLowError` regex breadth verified against `node_modules/viem`.

## Ship Checklist
- [x] ship skill used
- [x] local review + codex review run (codex's broad-nonce-match finding applied)
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live mainnet relay submission (RPC selection, nonce retry, and error handling); misconfigured secrets or overly broad nonce retries could affect relay success, though dedicated-RPC logging is redacted.
> 
> **Overview**
> Addresses Celo mainnet relay failures from stale public RPC nonce reads by wiring an optional **dedicated Celo RPC** (Secret Manager → `RPC_URL_SECRET_ID` on the celo function only) and using a shared viem **`fallback([dedicated, public])`** transport for public and wallet clients.
> 
> **`relay.ts`** adds one-time transport init (no cache on failed secret load), **redacts** the dedicated URL from logged viem errors, wraps RPC-touching work in a broader try/catch, and **retries once** when the error message is a strict **"nonce too low"** (not broader `NonceTooLowError` cases like already-imported txs).
> 
> **Terraform/README** document optional `celo_rpc_url` on mainnet; **`package.json`** pins **`uuid` 11.1.1** via overrides (lockfile cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b02abe553c3cbf1ad0994e49ddfeebaadb42ded4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->