### PR TITLE
fix: update Cloud Run logs URL + make worktrees self-sufficient

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -f package.json ] && [ ! -d node_modules ]; then echo 'node_modules missing (fresh worktree?) — running npm ci...' && npm ci --silent && echo 'npm ci done.'; fi",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ pnpm-lock.yaml
 # Local Stuff
 .project_vars_cache
 
-.claude/
+# Ignore .claude except shared project settings (SessionStart hook for worktree setup)
+.claude/*
+!.claude/settings.json

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -3,3 +3,5 @@
 # terraform workspace selected and no cached project vars.
 .project_vars_cache
 infra/.terraform/environment
+# Needed by `npm start` and the is-local-function-working pre-push hook.
+.env

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,5 @@
+# Files copied into new Claude Code worktrees (gitignore syntax; only gitignored files are copied).
+# Without these, bin/get-project-vars.sh fails because fresh worktrees have no
+# terraform workspace selected and no cached project vars.
+.project_vars_cache
+infra/.terraform/environment

--- a/bin/get-function-logs-url.sh
+++ b/bin/get-function-logs-url.sh
@@ -53,7 +53,7 @@ EOF
 
 	echo ""
 
-	cloud_run_logs_url="https://console.cloud.google.com/run/detail/${region}/${function_name}/logs?project=${project_id}"
+	cloud_run_logs_url="https://console.cloud.google.com/run/detail/${region}/${function_name}/observability/logs?project=${project_id}"
 	printf '\n\033[1mCloud Run Logs\033[0m - The underlying Cloud Run logs, mainly for problems occurring during startup of the function.\n%s\n' "${cloud_run_logs_url}"
 }
 

--- a/bin/get-project-vars.sh
+++ b/bin/get-project-vars.sh
@@ -174,6 +174,17 @@ set_chain_vars() {
 		exit 1
 	fi
 
+	# Guard against a stale/mismatched environment (e.g. a cached mainnet
+	# project while requesting a testnet chain), which would silently
+	# generate URLs/commands for the wrong GCP project.
+	local expected_env
+	expected_env=$(chain_to_env "${chain}")
+	if [[ ${env} != "${expected_env}" ]]; then
+		printf '\n\033[1;31mError: Chain '\''%s'\'' requires the '\''%s'\'' environment, but the current environment is '\''%s'\''.\033[0m\n' "${chain}" "${expected_env}" "${env}" >&2
+		echo "Please run 'terraform -chdir=infra workspace select ${expected_env}' and then 'npm run cache:clear'." >&2
+		exit 1
+	fi
+
 	export function_name="relay-${chain}"
 	export topic_name="relay-${env}-${chain}"
 }

--- a/bin/get-project-vars.sh
+++ b/bin/get-project-vars.sh
@@ -181,7 +181,7 @@ set_chain_vars() {
 	expected_env=$(chain_to_env "${chain}")
 	if [[ ${env} != "${expected_env}" ]]; then
 		printf '\n\033[1;31mError: Chain '\''%s'\'' requires the '\''%s'\'' environment, but the current environment is '\''%s'\''.\033[0m\n' "${chain}" "${expected_env}" "${env}" >&2
-		echo "Please run 'terraform -chdir=infra workspace select ${expected_env}' and then 'npm run cache:clear'." >&2
+		echo "Please run 'npm run ${expected_env}' to switch workspaces and clear the cache." >&2
 		exit 1
 	fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -515,18 +515,6 @@
         "winston": ">=3.2.1"
       }
     },
-    "node_modules/@google-cloud/logging/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
@@ -2991,18 +2979,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/gcp-metadata": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
@@ -3163,18 +3139,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/google-gax/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gopd": {
@@ -5076,18 +5040,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -5288,10 +5240,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "overrides": {
     "form-data": "2.5.5",
     "@tootallnate/once": "3.0.1",
-    "tar": "7.5.15"
+    "tar": "7.5.15",
+    "uuid": "11.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- Update the Cloud Run logs URL in `bin/get-function-logs-url.sh` to GCP's new path: `/run/detail/<region>/<service>/observability/logs` (the old `/logs` path is gone).
- Make `claude --worktree` worktrees fully functional from the get-go:
  - `.worktreeinclude` copies `.project_vars_cache`, `infra/.terraform/environment`, and `.env` into every new worktree. Fresh worktrees previously failed `bin/get-project-vars.sh` (no terraform workspace selected) and the `is-local-function-working` pre-push hook (no `.env`).
  - A shared `SessionStart` hook (`.claude/settings.json`, now un-ignored) runs `npm ci` once when `node_modules` is missing, so all dev commands work immediately in a new worktree session.
- Add a chain↔environment guard in `set_chain_vars()` (`bin/get-project-vars.sh`): requesting a testnet chain while the cached environment is mainnet (or vice versa) now fails loudly with remediation (`npm run <env>`) instead of silently generating URLs/commands for the wrong GCP project. Surfaced by review: an inherited cache in a worktree made this silent-wrong-project case more likely.

## Test plan
- [x] `./bin/get-function-logs-url.sh celo` prints the new-format URL: `https://console.cloud.google.com/run/detail/europe-west1/relay-celo/observability/logs?project=oracle-relayer-mainnet-0527`
- [x] Simulated worktree copy (`infra/.terraform/environment` + `.project_vars_cache` + `.env`): `terraform workspace show` reports `mainnet`, scripts run without terraform init
- [x] Env guard: `set_chain_vars celo-sepolia` with mainnet cache exits 1 with error; `set_chain_vars celo` works (`relay-celo` / `relay-mainnet-celo`)
- [x] Gitignore exception verified: `.claude/settings.json` tracked, `.claude/worktrees` + `settings.local.json` still ignored; hook JSON validates and no-ops when `node_modules` exists
- [x] `trunk fmt` + `trunk check` clean; pre-push hook (`npm start` smoke test) passed

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to dev scripts, gitignore/worktree config, and a dependency override; no runtime relay logic.
> 
> **Overview**
> Fixes **Cloud Run** console links in `get-function-logs-url.sh` by switching from the removed `/logs` path to **`/observability/logs`**.
> 
> Improves **Claude Code worktrees** so new checkouts are usable without manual setup: **`.worktreeinclude`** copies `.project_vars_cache`, `infra/.terraform/environment`, and `.env`; **`.claude/settings.json`** is tracked (with a **SessionStart** hook that runs **`npm ci`** when `node_modules` is missing); **`.gitignore`** ignores `.claude/*` except that file.
> 
> Adds a **chain ↔ Terraform environment** check in **`set_chain_vars()`** so a testnet chain with a mainnet cache (or the reverse) **errors** and points at `npm run <env>` instead of building URLs/commands for the wrong GCP project.
> 
> Pins **`uuid` to 11.1.1** via **`package.json` overrides** (lockfile cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6dd23eafacd9c520f7078f48fbfd679097c38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->