### PR TITLE
perf: sample the TimestampNotNew skip diagnostic (1 in 10)

### DIFF
--- a/src/relay.ts
+++ b/src/relay.ts
@@ -44,6 +44,9 @@ const chainMap: Record<typeof config.CHAIN, Chain> = {
   "polygon-testnet": polygonAmoy,
 };
 
+// Fraction of TimestampNotNew skips that fetch the full RPC diagnostic (1 in 10)
+const SKIP_DIAGNOSTIC_SAMPLE_RATE = 0.1;
+
 // Re-use clients across function invocations to save on initialization time and memory
 let publicClient: PublicClient;
 const walletClients: Map<string, WalletClient> = new Map<
@@ -350,7 +353,15 @@ async function handleContractFunctionRevertError(
   const errName = revertError.data?.errorName ?? "";
   switch (errName) {
     case "TimestampNotNew": {
-      const diagnostic = await getRelayDiagnostic(relayerContract, client);
+      // ~75-80% of minutes end here (no new Chainlink round yet), and the
+      // diagnostic costs 7-8 RPC reads per call — at 19 feeds x 1/min it was
+      // ~70% of all RPC traffic (which is billed per request on the dedicated
+      // endpoint). Sample it instead of fetching it every time; the warn paths
+      // below keep the full diagnostic unconditionally.
+      const diagnostic =
+        Math.random() < SKIP_DIAGNOSTIC_SAMPLE_RATE
+          ? await getRelayDiagnostic(relayerContract, client)
+          : undefined;
       logger.info(
         "Relay skipped. Chainlink timestamp is not newer than SortedOracles median timestamp",
         diagnostic ?? undefined,


### PR DESCRIPTION
## The Problem

- With #52's dedicated QuickNode RPC, **every** viem request is billed in API credits (20/call on the Build plan, 500M/month budget).
- ~75–80% of relay invocations end in a `TimestampNotNew` skip (no new Chainlink round yet), and each skip fetched the full `getRelayDiagnostic` — **7–8 eth_calls** of pure observability.
- Projected load: ~160 req/min across 19 celo feeds ≈ **~7M requests ≈ ~140M credits/month (28% of plan)** — ~70% of it the skip diagnostic.

## The Solution

Sample the diagnostic at **1-in-10** on the info-level skip path only. The skip line itself still logs every minute; ~1,600 sampled diagnostics/day fleet-wide remain for debugging. The WARN paths (`ExpiredTimestamp`, `TimestampSpreadTooHigh`) keep the full diagnostic unconditionally — that's where it earns its keep (they're rare and always actionable).

**Expected after this change: ~3M requests ≈ ~60M credits/month (~12% of plan)** — ~3.5× → ~8× headroom.

## Details

- `SKIP_DIAGNOSTIC_SAMPLE_RATE = 0.1` module constant; plain `Math.random()` gate — no per-feed state needed, statistically every feed still logs a diagnostic ~every 10 minutes.
- No metric/alert impact: the `successful_relay_count` metric matches "Relay succeeded", Grafana oracle-liveness alerts read on-chain state; nothing consumes skip-diagnostic fields programmatically.

## Validation

- `tsc --noEmit`, `eslint`, `trunk check` — clean
- Cost math derived from per-path call counts in `relay.ts` (skip = 1 simulate + 7–8 diagnostic reads; relay ≈ 9–10 calls) × 19 feeds × 1/min, QuickNode = 20 credits/method ([API credits](https://www.quicknode.com/api-credits/eth))

## Ship Checklist
- [x] ship skill used (follow-up)
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Relay behavior is unchanged; only observability RPC volume on the benign skip path is reduced.
> 
> **Overview**
> Cuts **QuickNode RPC cost** on the common `TimestampNotNew` skip path by fetching `getRelayDiagnostic` (7–8 `eth_call`s) only **~10%** of the time via a new `SKIP_DIAGNOSTIC_SAMPLE_RATE` and `Math.random()` gate in `handleContractFunctionRevertError`.
> 
> The **info-level skip log still runs every minute**; most entries omit the diagnostic payload. **`ExpiredTimestamp` and `TimestampSpreadTooHigh` warn paths are unchanged** and still always load the full diagnostic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382716e739ed0501ec7b81f371e839fa9cfdc25b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->