### PR TITLE
docs: document self-bootstrapping Claude Code worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Worktrees created via `claude --worktree` are self-bootstrapping — no manual s
 - [`.worktreeinclude`](.worktreeinclude) copies the gitignored `.env`, `.project_vars_cache`, and `infra/.terraform/environment` (terraform workspace marker) from the main checkout into every new worktree.
 - A `SessionStart` hook in [`.claude/settings.json`](.claude/settings.json) runs `npm ci` once when `node_modules` is missing.
 
-Note: the copied cache pins the worktree to whatever environment the main checkout had selected. `bin/get-project-vars.sh` fails loudly on a chain↔environment mismatch; fix with `npm run testnet` / `npm run mainnet`.
+Note: the copied cache pins the worktree to whatever environment the main checkout had selected. `bin/get-project-vars.sh` fails loudly on a chain↔environment mismatch. To switch environments, run `./bin/set-up-terraform.sh` first (fresh worktrees only carry the workspace marker, not an initialized terraform backend, so `terraform workspace select` would fail), then `npm run testnet` / `npm run mainnet`.
 
 ## Switching between environments
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ Each environment hosts multiple cloud functions (one per chain), sharing the sam
    npm run test:monad-testnet "AUSD/USD"
    ```
 
+### Git worktrees (Claude Code)
+
+Worktrees created via `claude --worktree` are self-bootstrapping — no manual setup needed:
+
+- [`.worktreeinclude`](.worktreeinclude) copies the gitignored `.env`, `.project_vars_cache`, and `infra/.terraform/environment` (terraform workspace marker) from the main checkout into every new worktree.
+- A `SessionStart` hook in [`.claude/settings.json`](.claude/settings.json) runs `npm ci` once when `node_modules` is missing.
+
+Note: the copied cache pins the worktree to whatever environment the main checkout had selected. `bin/get-project-vars.sh` fails loudly on a chain↔environment mismatch; fix with `npm run testnet` / `npm run mainnet`.
+
 ## Switching between environments
 
 - There are 2 GCP projects: one for testnet chains and one for mainnet chains


### PR DESCRIPTION
## Summary
- Follow-up to #53: documents the worktree bootstrap mechanism (`.worktreeinclude` file copies + `SessionStart` npm ci hook) in the README's Local Setup section, including the environment-pinning caveat and its remediation.

## Test plan
- [x] Docs-only change; links verified against files shipped in #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or infrastructure impact.
> 
> **Overview**
> Adds a **Git worktrees (Claude Code)** subsection under Local Setup that explains how `claude --worktree` checkouts bootstrap themselves.
> 
> It documents that `.worktreeinclude` copies gitignored `.env`, `.project_vars_cache`, and `infra/.terraform/environment` from the main tree, and that `.claude/settings.json` runs `npm ci` on session start when `node_modules` is absent. It also warns that the copied cache pins the worktree to the main checkout’s GCP/terraform environment and gives remediation: run `./bin/set-up-terraform.sh` before `npm run testnet` / `npm run mainnet` when switching (because fresh worktrees lack an initialized terraform backend).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9eacd447447769096fd7a523c04ad29b23b669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->