### PR TITLE
fix: pass --project to gcloud calls in bin scripts

### DIFF
--- a/bin/get-job-logs-url.sh
+++ b/bin/get-job-logs-url.sh
@@ -53,7 +53,7 @@ validate_rate_feed_description() {
 
 check_if_job_exists() {
 	# Check if the scheduler job exists
-	if ! gcloud scheduler jobs describe "${1}" --location "${region}" &>/dev/null; then
+	if ! gcloud scheduler jobs describe "${1}" --project "${project_id}" --location "${region}" &>/dev/null; then
 		printf "\n"
 		echo "❌ Error: Scheduler job '${1}' does not exist in Google Cloud." >&2
 		exit 1

--- a/bin/get-job-logs.sh
+++ b/bin/get-job-logs.sh
@@ -54,7 +54,7 @@ validate_rate_feed_description() {
 
 check_if_job_exists() {
 	# Check if the scheduler job exists
-	if ! gcloud scheduler jobs describe "${1}" --location "${region}" &>/dev/null; then
+	if ! gcloud scheduler jobs describe "${1}" --project "${project_id}" --location "${region}" &>/dev/null; then
 		printf "\n"
 		echo "❌ Error: Scheduler job '${1}' does not exist in Google Cloud." >&2
 		exit 1
@@ -70,6 +70,7 @@ printf "\n"
 start_spinner "Fetching job logs..."
 
 gcloud logging read "resource.type=cloud_scheduler_job AND resource.labels.job_id=${scheduler_job_id}" \
+	--project "${project_id}" \
 	--limit=20 \
 	--format="table(timestamp,insertId,jsonPayload.pubsubTopic)"
 

--- a/bin/test-deployed-function.sh
+++ b/bin/test-deployed-function.sh
@@ -47,7 +47,7 @@ test_deployed_function() {
 
 	echo "🌀 Emitting a Pubsub event to trigger the function..."
 	printf "\n"
-	gcloud pubsub topics publish "${topic_name}" --message="{\"rate_feed_name\": \"${rate_feed_id}\", \"relayer_address\": \"${address}\"}"
+	gcloud pubsub topics publish "${topic_name}" --project "${project_id}" --message="{\"rate_feed_name\": \"${rate_feed_id}\", \"relayer_address\": \"${address}\"}"
 	printf "\n"
 
 	echo "✅ Pubsub event emitted!"


### PR DESCRIPTION
## Problem

Three `bin/` scripts run `gcloud` commands against whatever project your local gcloud happens to have active. `get-project-vars.sh` only runs `gcloud config set project` on a **cache miss** — on a cache hit it just sources `.project_vars_cache` into shell vars. So after working in any other GCP project (e.g. `mento-monitoring`):

- `test-deployed-function.sh` → `NOT_FOUND: Resource not found (resource=relay-mainnet-celo)` on publish (hit this for real during the post-#52 deploy verification)
- `get-job-logs.sh` / `get-job-logs-url.sh` → scheduler describe + logging read silently query the wrong project

## Fix

Pass `--project "${project_id}"` explicitly at all 4 call sites, matching what `deploy-via-gcloud.sh`, `get-function-logs.sh`, and `tail-function-logs.sh` already do. After this, every gcloud call site in `bin/` is pinned.

## Verification

Staged the failure mode with `CLOUDSDK_CORE_PROJECT=mento-monitoring` (env var acts as the active project; an explicit `--project` flag outranks it):

- `get-job-logs.sh celo PHP/USD` → returned real scheduler logs from `projects/oracle-relayer-mainnet-0527/...` ✅
- `test-deployed-function.sh celo PHP/USD` → publish succeeded (`messageId 19956080898699977`) — the exact command shape that NOT_FOUND'ed before ✅
- `bash -n` + `trunk check` clean on all three scripts ✅

## Ship Checklist
- [x] ship skill used
- [x] local review run (sibling-call-site audit across all bin/ gcloud usages)
- [x] validation run (runtime probes above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI-only changes that make gcloud calls more deterministic; no runtime service or auth logic changes.
> 
> **Overview**
> Pins three operational `bin/` scripts to the chain-specific GCP project from `get-project-vars.sh` by passing **`--project "${project_id}"`** on every `gcloud` call they make.
> 
> **`get-job-logs-url.sh`** and **`get-job-logs.sh`** now pass the project flag on scheduler job `describe` (and on `logging read` in the logs script). **`test-deployed-function.sh`** does the same for Pub/Sub topic publish. This matches scripts like `deploy-via-gcloud.sh` and avoids hitting the wrong project when the local gcloud default or env active project does not match the relayer project (e.g. cache hit without `gcloud config set project`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ddd5240d7b354b615bf18aefd2a337ec60ff7c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->