### PR TITLE
fix(alerts): retire aggregate relayer paging

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -110,14 +110,14 @@ Add `for_each = local.chain_configs` to both resources:
 | `relayer_mnemonic`    | No change (one per project, shared across functions)                                                                                                                      |
 | `discord_webhook_url` | No longer per-chain. One per environment using `local.discord_webhook_url`. Secret ID: `discord-webhook-url-${terraform.workspace}` (e.g., `discord-webhook-url-testnet`) |
 
-### 1.6 `infra/monitoring.tf` — Per-Chain Metrics, Per-Environment Channels
+### 1.6 Chain-level GCP paging — Retired
 
-| Resource                                                   | Change                                                                                                                      |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `google_logging_metric.successful_relay_count`             | Add `for_each = local.chain_configs`. Metric name: `successful_relay_count_${each.key}`. Filter by function name per chain. |
-| `google_monitoring_notification_channel.discord_channel`   | Stays singular. Uses `local.discord_webhook_url`.                                                                           |
-| `google_monitoring_notification_channel.victorops_channel` | Stays singular.                                                                                                             |
-| `google_monitoring_alert_policy.successful_relay_policy`   | Add `for_each = local.chain_configs`. One alert per chain.                                                                  |
+The successful-relay metric remains available as non-paging telemetry, but its
+GCP alert policy and notification channel were removed after this migration.
+Successful transactions follow each feed's source cadence, so aggregating them
+by chain produced false pages during FX market closures. Per-feed freshness paging now lives in
+`monitoring-monorepo/alerts/rules/`, where FX weekend muting is applied without
+silencing continuously updating feeds.
 
 ### 1.7 `infra/variables.tf` — Variable Changes
 
@@ -352,7 +352,7 @@ At any point before destroying old projects:
 | `infra/pubsub.tf`               | Add `for_each` for topics + schemas, include environment in naming                         |
 | `infra/scheduler.tf`            | Change `for_each` to flattened `all_scheduler_jobs` map                                    |
 | `infra/secret-manager.tf`       | Simplify discord webhook to per-environment                                                |
-| `infra/monitoring.tf`           | Add `for_each` for metrics + alerts, keep channels singular                                |
+| `infra/monitoring.tf`           | Retain success-count telemetry; paging moved to `monitoring-monorepo`                      |
 | `infra/local-dotenv-file.tf`    | Use `var.local_dev_chain` for CHAIN value                                                  |
 | `infra/variables.tf`            | Add `local_dev_chain`, rename discord webhook vars to per-environment                      |
 | `infra/terraform.tfvars`        | Rename discord webhook var names                                                           |

--- a/README.md
+++ b/README.md
@@ -106,9 +106,6 @@ Each environment hosts multiple cloud functions (one per chain), sharing the sam
    # / #alerts-testnet (testnet), prefixed with [chain][feed].
    slack_bot_token      = "<slack-bot-token>"
 
-   # Get it from our VictorOps by going to `Integrations` > `Stackdriver` and copying the URL. The routing key can be found under the settings tab
-   victorops_webhook_url   = "<victorops-webhook-url>/<victorops-routing-key>"
-
    # Optional (mainnet only): dedicated Celo RPC URL (e.g. a QuickNode HTTPS endpoint).
    # When set, the relayer uses it as the primary RPC and falls back to the public
    # Forno RPC. Leave unset to use only the public RPC. Stored in Secret Manager.
@@ -181,6 +178,12 @@ For most local `terraform` or `gcloud` problems, your first steps should always 
 ## Viewing Logs
 
 The Oracle Relayer uses structured logging with Google Cloud Logging. Logs include severity levels, timestamps, rate feed labels, and trace IDs for correlating function invocations.
+
+Relayer paging is owned by the per-feed Grafana rules in
+`mento-protocol/monitoring-monorepo/alerts/rules/`. FX feeds are muted during
+the configured weekend market closure; feeds that update continuously remain
+pageable. Do not add chain-level "no successful relay" alerts here: successful
+transactions follow each feed's source cadence and are not a service heartbeat.
 
 ### Quick Start
 

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -1,10 +1,12 @@
-# Creates a metric per chain that counts the number of log entries containing 'Relay succeeded' in the relay cloud function.
+# Retain per-feed success counts as non-paging telemetry. Paging is owned by
+# the market-hours-aware, per-feed Grafana rules in monitoring-monorepo.
 resource "google_logging_metric" "successful_relay_count" {
   for_each    = local.chain_configs
   project     = module.oracle_relayer.project_id
   name        = "successful_relay_count_${each.key}"
   description = "Number of log entries containing 'Relay succeeded' in the ${each.key} relay cloud function"
-  # NOTE: the relayer logs through the Cloud Logging API (winston) with a
+
+  # The relayer logs through the Cloud Logging API (winston) with a
   # cloud_run_revision resource — gen2 functions never emit the gen1
   # cloud_function/function_name labels, so filtering on those matches nothing.
   filter = <<EOF
@@ -27,66 +29,4 @@ resource "google_logging_metric" "successful_relay_count" {
   label_extractors = {
     "ratefeed" = "EXTRACT(labels.rateFeed)"
   }
-}
-
-# Splunk notification channel for on-call alerts
-resource "google_monitoring_notification_channel" "victorops_channel" {
-  project      = module.oracle_relayer.project_id
-  display_name = "Splunk (VictorOps)"
-  type         = "webhook_tokenauth"
-
-  labels = {
-    url = var.victorops_webhook_url
-  }
-}
-
-# Creates an alert policy per chain that triggers when no successful relay logs have been received in the last 30 minutes,
-# and sends a notification to Splunk.
-resource "google_monitoring_alert_policy" "successful_relay_policy" {
-  # Mainnet only: testnet relays once a day (see scheduler.tf), so a 30-minute
-  # absence window would page nearly continuously there — and a daily cadence
-  # can't support log-absence alerting at all (a healthy run that skips on
-  # TimestampNotNew emits no success log either). The metric itself stays in
-  # both workspaces for dashboards.
-  for_each     = terraform.workspace == "mainnet" ? local.chain_configs : {}
-  project      = module.oracle_relayer.project_id
-  display_name = "no-successful-relay-logs-${each.key}"
-  combiner     = "OR" # Not used in practice because we only have one condition, but it's required by the API
-  enabled      = true
-
-  documentation {
-    content = "No successful relay events on ${each.key} in the past 30 minutes — the relay function has likely stopped relaying entirely. Per-feed staleness is covered by the Grafana oracle-liveness alerts."
-  }
-
-  conditions {
-    display_name = "No successful relay logs for ${each.key} in 30 minutes"
-
-    # condition_absent instead of a LT-threshold: a log-based DELTA metric emits
-    # NO points at all when nothing matches, and a threshold condition does not
-    # evaluate on missing data — i.e. the exact scenario this alert exists for
-    # (relays stopped entirely) would never page. Absence is the canonical
-    # "no logs in X minutes" shape. Scoped per chain (REDUCE_SUM across feeds);
-    # per-feed staleness is the Grafana oracle-liveness alerts' job.
-    condition_absent {
-      filter = <<EOF
-        resource.type = "cloud_run_revision" AND
-        metric.type   = "logging.googleapis.com/user/${google_logging_metric.successful_relay_count[each.key].name}"
-      EOF
-
-      duration = "1800s" # 30 minutes without a single successful relay on this chain
-
-      aggregations {
-        alignment_period     = "300s"
-        per_series_aligner   = "ALIGN_COUNT"
-        cross_series_reducer = "REDUCE_SUM"
-      }
-
-      trigger {
-        count = 1
-      }
-    }
-  }
-
-  notification_channels = [google_monitoring_notification_channel.victorops_channel.id]
-  severity              = "CRITICAL"
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -55,14 +55,6 @@ variable "rpc_url_secret_id" {
   type    = string
   default = "celo-rpc-url"
 }
-# Webhook URL to send monitoring alerts from within GCP Monitoring
-# You can find this URL in Victorops by going to "Integrations" -> "Stackdriver".
-# The routing key can be found under "Settings" -> "Routing Keys"
-variable "victorops_webhook_url" {
-  type      = string
-  sensitive = true
-}
-
 # You can look this up via:
 #  `gcloud secrets list`
 variable "slack_bot_token_secret_id" {


### PR DESCRIPTION
## The Problem

- A chain-wide GCP alert pages after 30 minutes without any successful relay transaction, even though successful transactions follow each feed's source cadence.
- On Monad this creates repeated weekend incidents: FX feeds pause while healthy non-FX feeds update roughly hourly.

## The Solution

Remove the aggregate GCP alert policy and its VictorOps notification channel. Retain the success-count metric as non-paging telemetry; per-feed freshness paging remains owned by the market-hours-aware Grafana rules in `monitoring-monorepo`.

Also removes the now-unused VictorOps input and updates the README and historical migration notes to document the ownership boundary.

Related operator-copy improvement: mento-protocol/monitoring-monorepo#1369

## Validation

- `terraform -chdir=infra fmt -check -recursive`
- `TF_WORKSPACE=mainnet terraform -chdir=infra validate`
- `trunk check README.md MIGRATION_PLAN.md infra/monitoring.tf infra/variables.tf`
- pre-push TypeScript build and local function startup hook
- Codex-native fresh-context autoreview: clean

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reduces GCP on-call coverage for total relay outages until Grafana rules are trusted; Terraform apply will destroy alert policies and notification channels in GCP.
> 
> **Overview**
> **Retires false-positive chain-level paging** by deleting the mainnet-only GCP alert that fired when no successful relay logs appeared for 30 minutes, plus the VictorOps webhook notification channel and the `victorops_webhook_url` Terraform variable.
> 
> The per-chain `successful_relay_count` logging metrics **stay** for dashboards and telemetry; only paging moves to market-hours-aware per-feed rules in `monitoring-monorepo`.
> 
> **Docs** (`README.md`, `MIGRATION_PLAN.md`) now state that relayer on-call is owned by Grafana oracle-liveness rules (FX weekend muting) and warn against re-adding aggregate “no successful relay” alerts here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e53af2dd04848110ca07c8d08e9bbedf983a6f70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->