### PR TITLE
docs: add production deploy safety checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,18 @@ Before applying production Terraform changes:
    contain production secret values in cleartext:
 
    ```bash
+   set -euo pipefail
    git pull --ff-only origin main
-   test -z "$(git status --short)"
-   test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+   test -z "$(git status --short)" || {
+     echo "Refusing to plan from a dirty worktree" >&2
+     exit 1
+   }
+   test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" || {
+     echo "Refusing to plan when HEAD differs from origin/main" >&2
+     exit 1
+   }
    terraform -chdir=infra workspace select mainnet
-   relayer_plan="$(mktemp /private/tmp/oracle-relayer-mainnet.tfplan.XXXXXX)"
+   relayer_plan="$(mktemp "${TMPDIR:-/tmp}/oracle-relayer-mainnet.tfplan.XXXXXX")"
    trap 'rm -f "$relayer_plan"' EXIT
    terraform -chdir=infra plan -out="$relayer_plan"
    ```

--- a/README.md
+++ b/README.md
@@ -179,13 +179,30 @@ For most local `terraform` or `gcloud` problems, your first steps should always 
 
 Before applying production Terraform changes:
 
-1. Sync the checkout with `origin/main` and select the `mainnet` workspace.
-2. Save a fresh plan and inspect every destructive change, especially removals
-   from chain-keyed `for_each` resources.
-3. Apply the exact saved plan that was reviewed.
-4. Confirm every deployed function is active, then check fresh success and error
-   logs for each chain.
-5. Run a final plan and require `No changes` before closing the deployment.
+1. Sync the checkout with `origin/main`, require a clean worktree at the same
+   commit as `origin/main`, and select the `mainnet` workspace.
+2. Save the plan in a restricted temporary file because Terraform plan files
+   contain production secret values in cleartext:
+
+   ```bash
+   git pull --ff-only origin main
+   test -z "$(git status --short)"
+   test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+   terraform -chdir=infra workspace select mainnet
+   relayer_plan="$(mktemp /private/tmp/oracle-relayer-mainnet.tfplan.XXXXXX)"
+   trap 'rm -f "$relayer_plan"' EXIT
+   terraform -chdir=infra plan -out="$relayer_plan"
+   ```
+
+3. Inspect every planned addition, update, replacement, and removal. Pay special
+   attention to chain- and feed-keyed `for_each` resources and scheduler payloads.
+4. Apply only the reviewed saved plan with
+   `terraform -chdir=infra apply "$relayer_plan"`.
+5. Confirm every deployed function is active. For every affected feed, verify
+   its scheduler and a fresh invocation with the expected `rateFeed` label, and
+   check error logs for each affected chain.
+6. Run a final plan, require `No changes`, then delete the saved plan with
+   `rm -f "$relayer_plan"` before closing the deployment.
 
 ## Viewing Logs
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,18 @@ For most local `terraform` or `gcloud` problems, your first steps should always 
 - Clear your local shell script cache via `npm run cache:clear`
 - Re-run the Terraform setup script via `./bin/set-up-terraform.sh`
 
+## Production Deployment Safety
+
+Before applying production Terraform changes:
+
+1. Sync the checkout with `origin/main` and select the `mainnet` workspace.
+2. Save a fresh plan and inspect every destructive change, especially removals
+   from chain-keyed `for_each` resources.
+3. Apply the exact saved plan that was reviewed.
+4. Confirm every deployed function is active, then check fresh success and error
+   logs for each chain.
+5. Run a final plan and require `No changes` before closing the deployment.
+
 ## Viewing Logs
 
 The Oracle Relayer uses structured logging with Google Cloud Logging. Logs include severity levels, timestamps, rate feed labels, and trace IDs for correlating function invocations.


### PR DESCRIPTION
## Summary
- document the safe production Terraform deployment sequence
- require destructive-change review, per-chain log verification, and a clean post-apply plan

## Validation
- `git diff --check`
- pre-push build and local function smoke check

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation with no runtime, Terraform, or infrastructure behavior changes.
> 
> **Overview**
> Adds a **Production Deployment Safety** section to the README with a five-step checklist for mainnet Terraform applies.
> 
> The steps require syncing with `origin/main` and the `mainnet` workspace, reviewing saved plans (with explicit attention to destructive changes on chain-keyed `for_each` resources), applying only the reviewed plan, verifying each chain’s functions and logs post-apply, and confirming a clean final `terraform plan` before sign-off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3248fd8fc5cc5fcd3acc2e48c9dd0bc1eacb1b83. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->